### PR TITLE
add python cryptographic authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,8 @@ We will review all requests and accept them at our discretion. If accepted, your
 ### Reddit Enhancement Suite
 Community-driven unofficial browser extension for Reddit. [Link to project](https://redditenhancementsuite.com/)
 
+### Python Cryptographic Authority
+A group managing the development of most of Python's major cryptographic libraries including [pyca/cryptography](https://cryptography.io), [pyNaCl](https://github.com/pyca/pynacl), and [pyOpenSSL](https://github.com/pyca/pyopenssl). [Link to project](https://github.com/pyca)
+
 ### PKIjs
 PKIjs is a pure JavaScript library implementing the formats that are used in PKI applications (signing, encryption, certificate requests, OCSP and TSP requests/responses). It is built on WebCrypto (Web Cryptography API) and requires no plug-ins. [Link to project](https://github.com/PeculiarVentures/PKI.js)


### PR DESCRIPTION
## Your project

**1Password Teams url**: python-cryptographic-authority.1password.com

**Project name**:  Python Cryptographic Authority

**Short description**: We are an umbrella for the development and maintenance of most of the major cryptographic libraries in Python.

**Project age**: ~4 years

**Number of core contributors**: 4-7

**Project website**: https://github.com/pyca (and individual sites like https://cryptography.io and https://pyopenssl.org)

**Repository url**: https://github.com/pyca

**Latest release url**: https://github.com/pyca/cryptography/releases/tag/2.2.2, https://github.com/pyca/pynacl/releases/tag/1.2.1, and many others.

**License type**: Apache 2, 3 clause BSD, and MIT across the set of supported projects.

**License url**: https://github.com/pyca/cryptography/blob/master/LICENSE, https://github.com/pyca/pynacl/blob/master/LICENSE, https://github.com/pyca/pyopenssl/blob/master/LICENSE, https://github.com/pyca/bcrypt/blob/master/LICENSE, https://github.com/pyca/service_identity/blob/master/LICENSE


## Tell us about yourself

**Name**: Paul Kehrer

**Email**: paul.l.kehrer@gmail.com

**Project role**: core contributor

**Website**: https://github.com/reaperhulk, https://langui.sh