### PR TITLE
WordCamp US Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ Community-driven unofficial browser extension for Reddit. [Link to project](http
 
 ### PKIjs
 PKIjs is a pure JavaScript library implementing the formats that are used in PKI applications (signing, encryption, certificate requests, OCSP and TSP requests/responses). It is built on WebCrypto (Web Cryptography API) and requires no plug-ins. [Link to project](https://github.com/PeculiarVentures/PKI.js)
+
+### Wordcamp US
+WordCamp US is the largest WordCamp in North America attracting roughly 2,000 in-person attendees from around the globe. WordCamps are low-cost, weekend events organized by dedicated teams of volunteers where WordPress enthusiasts and more gather to learn to get the most out of WordPress. [Link to project](https://2018.us.wordcamp.org)


### PR DESCRIPTION
Added the WordCamp US entry to the `Open source projects using 1Password Teams` section

## Your project

**1Password Teams url**: wordcampus.1password.com

**Project name**:  WordCamp US

**Short description**: WordCamp US is the largest WordCamp in North America attracting roughly 2,000 in-person attendees from around the globe. WordCamps are low-cost, weekend events organized by dedicated teams of volunteers where WordPress enthusiasts and more gather to learn to get the most out of WordPress.

**Project age**: WordCamp US has been happening since 2015, but WordCamps have been happening all over the world since 2006.

**Number of core contributors**: Our current organizing team has 20 members

**Project website**: https://2018.us.wordcamp.org

**Repository url**: https://github.com/wcus/wcus2018

**Latest release url**: https://github.com/wcus/wcus2018

**License type**: GPLv2 (or later)

**License url**:
https://wordpress.org/about/license/
https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html


## Tell us about yourself

**Name**: Brett Shumaker

**Email**: brett@brettshumaker.com

**Project role**: WordCamp US Website team

**Website**: link to GitHub profile page, project page bio, etc.
https://2017.us.wordcamp.org/organizers/
https://github.com/brettshumaker
https://brettshumaker.com
