### PR TITLE
Add the Vizzy project

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,45 @@
 ## Your project
 
 **1Password Teams url**: myteam.1password.com (create the account before applying).
+vizzy.1password.com
 
 **Project name**:  
+Vizzy
 
 **Short description**:
+Vizzy is a powerful Ruby on Rails web server that facilitates Visual Automation, a continuous integration testing strategy that aims to prevent visual regressions. It does this by performing pixel by pixel comparisons of screenshots captured during test runs. In doing so, it tests application data as well as application views.
 
 **Project age**: 
+2 years, just recently open sourced
 
 **Number of core contributors**:
+5
 
 **Project website**:
+https://github.com/Workday/vizzy
 
 **Repository url**:
+https://github.com/Workday/vizzy
 
 **Latest release url**:
+Docker project, not deployed for you.
 
 **License type**: e.g. MIT, BSD, GPL, etc.
+MIT
 
 **License url**: A copy of the license terms and conditions for your software.
-
+https://github.com/Workday/vizzy/blob/master/LICENSE
 
 ## Tell us about yourself
 
 **Name**: 
+Scott Bishop
 
 **Email**:
+scottbishop70@gmail.com
 
 **Project role**:
+Lead Contributor
 
 **Website**: link to GitHub profile page, project page bio, etc.
+https://github.com/ScottBishop


### PR DESCRIPTION
Your project
1Password Teams url: myteam.1password.com (create the account before applying). vizzy.1password.com

Project name:
Vizzy

Short description: Vizzy is a powerful Ruby on Rails web server that facilitates Visual Automation, a continuous integration testing strategy that aims to prevent visual regressions. It does this by performing pixel by pixel comparisons of screenshots captured during test runs. In doing so, it tests application data as well as application views.

Project age: 2 years, just recently open sourced

Number of core contributors: 5

Project website: https://github.com/Workday/vizzy

Repository url: https://github.com/Workday/vizzy

Latest release url: Docker project, not deployed for you.

License type: e.g. MIT, BSD, GPL, etc. MIT

License url: A copy of the license terms and conditions for your software. https://github.com/Workday/vizzy/blob/master/LICENSE

Tell us about yourself
Name: Scott Bishop

Email: scottbishop70@gmail.com

Project role: Lead Contributor

Website: link to GitHub profile page, project page bio, etc. https://github.com/ScottBishop