### PR TITLE
Add PyGotham

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ Titanium apps. It is built using Objective-C and is based on the [official Agile
 ### Broadcast
 The broadcast app is a way of connecting groups in chat rooms over SMS, no app required! Users can be invited, leave, and mute chat rooms with with others that have similar interests or friends of friends that haven't shared phone numbers yet. Text one number and broadcast your text to the whole group!  [Link to project](https://github.com/rkk09c/Broadcast)
 
+### PyGotham
+PyGotham is a New York City based, eclectic, Py-centric conference covering many topics. There’s a diverse speaker list, and some things which will be quite different. [Link to project](https://pygotham.org)


### PR DESCRIPTION
## PyGotham

**1Password Teams url**: bigapplepy.1password.com

**Project name**: PyGotham

**Short description**: PyGotham is New York City's annual Python conference.

**Project age**: 7 years

**Number of core contributors**: 7

**Project website**: https://pygotham.org

**Repository url**: https://gitlab.com/pygotham/2018

**Latest release url**: https://2018.pygotham.org

**License type**: BSD

**License url**: https://gitlab.com/pygotham/2018/blob/master/LICENSE


## Tell us about yourself

**Name**: Jon Banafato

**Email**: jon@pygotham.org

**Project role**: Organizer

**Website**: https://www.jonafato.com
