### PR TITLE
add cloud oscilloscope information at Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ Open Data Kit is a free and open-source set of tools for collecting data in chal
 ### Vizzy
 
 Vizzy is a powerful Ruby on Rails web server that facilitates Visual Automation, a continuous integration testing strategy that aims to prevent visual regressions. It does this by performing pixel by pixel comparisons of screenshots captured during test runs. In doing so, it tests application data as well as application views. [Link to project](https://github.com/Workday/vizzy)
+
+### Cloud Oscilloscope 
+
+A 45$ open source oscilloscope built on Orange Pi Zero, mcp3201 adc with custom shield and cheap spi-display. [Link to project](https://hackaday.io/project/90259-cloud-oscilloscope)


### PR DESCRIPTION
## Your project

**1Password Teams url**:cloud-oscilloscope.1password.com 

**Project name**:  Cloud Oscilloscope
**Short description**: Open-source oscilloscope built on Orange Pi Zero, mcp3201 adc with custom shield and cheap spi-display.
**Project age**: 1.5 year
**Number of core contributors**: 7
**Project website**: https://hackaday.io/project/90259-cloud-oscilloscope
**Repository url**: https://gitlab.com/cloud-oscilloscope/qtloscope
**Latest release url**: http://dronov.net/2018/04/05/cloud-oscilloscope-pcb-update.html
**License type**:  MIT
**License url**: https://gitlab.com/cloud-oscilloscope/qtloscope/blob/master/LICENSE


## Tell us about yourself

**Name**: Mikhail Dronov
**Email**: mike@dronov.net
**Project role**: Core developer, community manager
**Website**: http://dronov.net/