### PR TITLE
Add Moya

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,7 @@ A 45$ open source oscilloscope built on Orange Pi Zero, mcp3201 adc with custom 
 ### Telegram Bot PHP SDK
 
 The (Unofficial) Telegram Bot API PHP SDK. Lets you develop Telegram Bots easily! [Link to project](https://github.com/irazasyed/telegram-bot-sdk)
+
+### Moya
+
+Network abstraction layer written in Swift. [Link to project](https://github.com/Moya/Moya)

--- a/README.md
+++ b/README.md
@@ -169,8 +169,6 @@ https://github.com/edenlabllc/ehealth.api
 Think of Neos as an open source Content Application Platform based on its own PHP framework Flow.
 https://www.neos.io
 
-The (Unofficial) Telegram Bot API PHP SDK. Lets you develop Telegram Bots easily! [Link to project](https://github.com/irazasyed/telegram-bot-sdk)
-
 ### IndieWeb
 The IndieWeb community maintains [several tools and plugins](https://github.com/indieweb) for helping individuals own their online data and use their websites as a social network.
 https://indieweb.org


### PR DESCRIPTION
Hey guys, first of all, thanks so much for doing this. This is an awesome way of giving back to the community and we respect it a lot. Many of the Moya core teammates are using 1password and it's been great.

We were trying to figure out a way of sharing few keys like key to the bot or key to the Twitter account and it seems like the best option for us.

I went through the checklist few times and it seems like I've got it all, but if we are missing something please let me know. 😉 

## Your project

**1Password Teams url**: https://moyacore.1password.com

**Project name**:  Moya

**Short description**: Moya is a network abstraction layer written in Swift

**Project age**: 3+ years

**Number of core contributors**: 11

**Project website**: https://moya.github.io

**Repository url**: https://github.com/Moya/Moya

**Latest release url**: https://github.com/Moya/Moya/releases/tag/11.0.2

**License type**: MIT

**License url**: https://github.com/Moya/Moya/blob/master/License.md


## Tell us about yourself

**Name**: Łukasz Mróz

**Email**: thesunshinejr@gmail.com

**Project role**: Core contributor/maintainer

**Website**: http://sunshinejr.com