### PR TITLE
Add canvas.place

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ https://github.com/pyca
 PKIjs is a pure JavaScript library implementing the formats that are used in PKI applications (signing, encryption, certificate requests, OCSP and TSP requests/responses). It is built on WebCrypto (Web Cryptography API) and requires no plug-ins.
 https://github.com/PeculiarVentures/PKI.js
 
+### canvas.place
+canvas.place is a community-focused game, where people work together to make art. The aim of the game is to bring people together in a fun and new way.
+https://github.com/dynastic/place
+
 ### coreboot
 Open Source firmware for x86 and other architectures.
 https://www.coreboot.org


### PR DESCRIPTION
## Your project

**1Password Teams url**: dynastic.1password.com

**Project name**:  canvas.place

**Short description**: canvas.place is a community-focused game, where people work together to make art. The aim of the game is to bring people together in a fun and new way.

**Project age**: >1 year

**Number of core contributors**: 3 

**Project website**: https://canvas.place

**Repository url**: https://github.com/dynastic/place

**Latest release url**: https://github.com/dynastic/place/commit/14ccc29a8030191601ec3d3c228c041fa82f66cb

**License type**: APGL-3.0

**License url**: https://github.com/dynastic/place/blob/master/LICENSE


## Tell us about yourself

**Name**: Jamie Bishop

**Email**: jamie@dynastic.co

**Project role**: Lead developer

**Website**: https://github.com/nullpixel

**Note:** dynastic development is our open-source focused development team and we maintain and contribute to a lot of other projects (see https://github.com/dynastic). I'm not sure to what extent canvas.place falls into these guidelines, but we do release and maintain a lot of opensource software -- 1Password would be really useful for sharing credentials (we have some external contributors too, who would be able to be added as a guest to the team)

Thanks for considering.