### PR TITLE
Add RailsBridge NYC to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,7 @@ http://queueup.gg/
 ### PyContribs
 Group of open-source Python package maintainers.
 https://github.com/pycontribs/
+
+### RailsBridge NYC
+Group of Rubyists in New York City teaching people how to code their first website with Ruby on Rails.
+https://github.com/railsbridge-nyc


### PR DESCRIPTION
## Your project

**1Password Teams url**: railsbridge.1password.com (create the account before applying).

**Project name**:  RailsBridge

**Short description**: RailsBridge NYC was started in 2013 as a regional chapter of the main RailsBridge non-profit organization. We have established ourselves as an exemplary organization who maintains our own fork of the tutorial/workshop originally developed by RailsBridge and have adapted it to include a Vagrant as well as Docker options to augment the traditional Installfest that has proved to be challenging to new Ruby on Rails programmers.

**Project age**: 5 years

**Number of core contributors**: 15

**Project website**: 
About RailsBridge: http://railsbridge.org/
About the NYC Chapter: http://railsbridgenyc.org/
The code we maintain: https://github.com/railsbridge-nyc
List of the events we've held: https://www.bridgetroll.org/chapters/1

**Repository url**: https://github.com/railsbridge-nyc

**Latest release url**: https://github.com/railsbridge-nyc/docs

**License type**: MIT

**License url**: https://github.com/railsbridge-nyc/docs/blob/master/LICENSE.md


## Tell us about yourself

**Name**: Rachel Ober

**Email**: rachelober @ gmail.com

**Project role**: Chapter Founder, Chapter Leader, Workshop Organizer

**Website**: https://www.rachelober.com, https://github.com/rachelober
