### PR TITLE
Add PSF Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,6 @@ https://multitheftauto.com
 
 ### stylelint
 A mighty, modern CSS linter https://github.com/stylelint/stylelint
+
+### Python Software Foundation Infrastructure Team
+Support, improve, and administer Python community services such as [PyPI](https://pypi.org) and [The Python Homepage](https://www.python.org).


### PR DESCRIPTION
## Your project

**1Password Teams url**: psf-infra.1password.com

**Project name**:  Python Software Foundation Infrastructure

**Short description**:  Support, improve, and administer Python community services such as PyPI and The Python Homepage.

**Project age**: 4+ years

**Number of core contributors**: 4

**Project website**: https://wiki.python.org/psf/InfrastructureWG

**Repository url**: https://github.com/python/psf-salt

**Latest release url**: N/A

**License type**: MIT, and [Python License](https://opensource.org/licenses/Python-2.0)

**License url**: https://github.com/python/psf-salt/blob/master/LICENSE.txt


## Tell us about yourself

**Name**: Ernest W. Durbin III

**Email**: ernest@python.org

**Project role**: [PSF Infrastructure Working Group](https://wiki.python.org/psf/InfrastructureWG) - Chair

**Website**: https://github.com/ewdurbin