### PR TITLE
README: add entry for Go London User Group (London Gophers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,9 @@ A digital repository specifically built for archaeological data [Link to project
 
 ### ViaVersion
 Open source protocol translation addon for various Minecraft server platforms written in Java - https://github.com/MylesIsCool/ViaVersion
+
+### Go London User Group (London Gophers)
+The Go London User Group (GLUG) is a London UK-based community for anyone interested in the Go programming language.
+GLUG held their first Meetup on Wednesday, March 27, 2013, and since then the group has grown to over 2,500 members.
+Nowadays, GLUG is more commonly known as London Gophers.
+https://gophers.london


### PR DESCRIPTION
## Your project

Per Twitter DM with [Dave Teare](https://twitter.com/dteare?lang=en) who suggested as a non-profit Meetup we qualify for this programme.

**1Password Teams url**: golondonusergroup.1password.com

**Project name**:  Go London User Group (GLUG, aka London Gophers)

**Short description**:

> The Go London User Group (GLUG) is a London UK-based community for anyone interested in the Go programming language. We are a non-profit society, run by organisers in their spare time. 

**Project age**: GLUG held their first Meetup on Wednesday, March 27, 2013

**Number of core contributors**: 4 main organisers; 2,600+ members

**Project website**: https://gophers.london, although the majority of our work is done via our Meetup Group: https://www.meetup.com/Go-London-User-Group/

**Repository url**: 

Our main activity is via our Meetup page: https://www.meetup.com/Go-London-User-Group/. We also have a GitHub org which, somewhat by definition of what we do, is less active: https://github.com/go-london-user-group. 

**Latest release url**: Our December 2018 Meetup: https://www.meetup.com/Go-London-User-Group/events/256927219/

**License type**: n/a because we are a Meetup. We are open to all, with no membership or attendance fees.

**License url**: n/a

## Tell us about yourself

**Name**: Paul Jolly

**Email**: paul@myitcv.io

**Project role**: Co-organiser

**Website**: https://github.com/myitcv
