### PR TITLE
Add Vikebot to Open Source Projects using 1Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,7 @@ https://www.railsbridgeboston.org
 [Pony](https://ponylang.io) is an open-source, object-oriented, actor-model, capabilities-secure, high-performance programming language.
 
 https://ponylang.io
+
+### Vikebot
+Competitive coding and gaming combined like never before. Vikebot is a platform where you compete against others using your coding skills. You program your own player, a bot, which plays autonomously against other bots in a deathmatch. According to the results of these games we place you in a global ranking system.
+https://github.com/vikebot


### PR DESCRIPTION
## Your project

**1Password Teams url**: https://vikebot.1password.com

**Project name**:  Vikebot

**Short description**: A competitive online coding game. Fight against your friends! 

Vikebot is a platform where you compete against others using your coding skills. You program your own player, a bot, which plays autonomously against other bots in a deathmatch. According to the results of these games we place you in a global ranking system.

**Project age**: 2 1/2 years

**Number of core contributors**: 3 (@harwoeck @andileeb @lukaskurz)

**Project website**: https://vikebot.com/

**Repository url**: Vikebot consists of many different services and packages, which are all separated at repository level. Therefore Vikebot hasn't "the one repo" but rather a suite of them. All repos can be found at the Vikebot Github organization: https://github.com/vikebot

**Latest release url**: Services and components are released independently from each other, when they reach the next milestone. All releases are git-tagged using the semver convention. (Info: The GitHub GUI highlights all git-tags as releases)

**License type**: Apache-2.0

**License url**: https://github.com/vikebot/vikebot/blob/master/LICENSE


## Tell us about yourself

**Name**: Florian Harwöck

**Email**: florian@harwoeck.at

**Project role**: Co-Founder, Core Contributor, Backend lead

**Website**: https://harwoeck.at https://github.com/harwoeck
