### PR TITLE
Add Monolingual

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,3 +323,7 @@ https://github.com/vikebot
 ### AM
 [AM](https://github.com/bottleneckco/am) is an open-source web client for Apple Music, built with React and Apple's MusicKit JS framework.
 https://github.com/bottleneckco/am
+
+### Monolingual
+Monolingual is a program for removing unnecessary language resources from macOS, in order to reclaim several hundred megabytes of disk space.
+https://ingmarstein.github.io/Monolingual


### PR DESCRIPTION
## Your project

**1Password Teams url**: monolingual.1password.com

**Project name**:  Monolingual

**Short description**: Monolingual is a program for removing unnecessary language resources from macOS, in order to reclaim several hundred megabytes of disk space.

**Project age**: 2014

**Number of core contributors**: 2

**Project website**: https://ingmarstein.github.io/Monolingual

**Repository url**: https://github.com/IngmarStein/Monolingual

**Latest release url**: https://github.com/IngmarStein/Monolingual/releases/tag/v1.8.1

**License type**: GTP

**License url**: https://github.com/IngmarStein/Monolingual/blob/v1.8.1/LICENSE.txt


## Tell us about yourself

**Name**: Ingmar Stein

**Email**: ingmarstein@icloud.com

**Project role**: Project Lead

**Website**: https://github.com/IngmarStein