### PR TITLE
Add TwoFactorAuth.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,3 +584,7 @@ https://femiwiki.com
 ### Dados Abertos de Feira
 Transparency is one of the keys to fight corruption. The project Dados Abertos de Feira aims to be a portal of the public datasets available in the city of Feira de Santana, Bahia, Brazil, making the data available searchable and open for all.
 https://dadosabertosdefeira.com.br
+
+### TwoFactorAuth.org
+[TwoFactorAuth.org](https://twofactorauth.org) is a list of popular sites that support Two Factor Authentication (2FA), as well as the methods that they provide. We hope to aid consumers who are deciding between alternative services based on the security they offer for their customers. This project also serves as an indicator of general security efforts used on a site.
+You can help contribute to the project on our [GitHub repo](https://github.com/2factorauth/twofactorauth).


### PR DESCRIPTION
## Your project

**1Password Teams url**: myteam.1password.com (create the account before applying).

twofactorauth.1password.com

**Project name**:

TwoFactorAuth.org

**Short description**:

A list of popular sites and whether or not they accept Two Factor Authentication (2FA).

**Project age**:

First commit on Mar 9, 2014, currently around 6 years old.

**Number of core contributors**:

While we've had over 1,000 contributors to the project over the years (to which I'm personally very thankful for), there are currently 10-15 core contributors that maintain the project.

**Project website**:

https://twofactorauth.org

**Repository url**:

https://github.com/2factorauth/twofactorauth

**Latest release url**:

https://github.com/2factorauth/twofactorauth/releases

Because the project is continuously published to a website, commits to the [master branch](https://github.com/2factorauth/twofactorauth) between releases are automatically pushed to the [project website](https://twofactorauth.org).

**License type**: e.g. MIT, BSD, GPL, etc.

The MIT License

**License url**: A copy of the license terms and conditions for your software.

https://github.com/2factorauth/twofactorauth/blob/master/LICENSE


## Tell us about yourself

**Name**:

Jacob Munch

**Email**:

jacob@twofactorauth.org

**Project role**:

Contributor and member of the Core team.

**Website**: link to GitHub profile page, project page bio, etc.

https://github.com/jamcat22

---

On a more personal note, I've been using 1Password for years and love the work y'all do! I was super excited when I saw that 1Password had integrated our [data.json](https://twofactorauth.org/api/v1/data.json) file [back in 2018](https://blog.1password.com/introducing-watchtower-2.0-the-turret-becomes-a-castle/), and I'm so glad that 1Password makes enabling 2FA so user-friendly that even my grandfather uses it. 😄

A newer feature of the website is our API v2, which allows for retrieving a list of only the sites that support 2FA, as well as determining whether a site supports the standard TOTP (RFC-6238) implementation or a proprietary implementation of software-based 2FA. This means that, for example, 1Password could download just a list of the sites that support 2FA and only prompt for the user to add an OTP entry to 1Password for sites that support standard TOTP, rather than prompting for sites with proprietary implementations that cannot be saved in 1Password.

The old version of the API will continue to work and is still accessible at twofactorauth.org/api/v1/data.json (twofactorauth.org/data.json automatically redirects to this URL to avoid breaking existing implementations), but if y'all would like to learn more about the new API, you can view the [API v2 readme](https://github.com/2factorauth/twofactorauth/tree/master/api/v2#readme) as well as the [merged PR](https://github.com/2factorauth/twofactorauth/pull/4090) that added this functionality.

Let me know if you have any questions, and thank y'all so much!