### PR TITLE
Add Boston Golang entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,3 +592,7 @@ You can help contribute to the project on our [GitHub repo](https://github.com/2
 ### Bevry
 Bevry builds tools (such as software) and processes (such as communities and discussions) that grow the market share of collaborative wisdom.
 https://bevry.me
+
+### Boston Golang
+Boston Golang is a Boston based community for people working with the Go programming language to discuss ideas, issues and share solutions. Boston Golang held their first Meetup on October 21, 2014 and as of April 2020 the group counts more than 1,700 members. Boston Golang is the only community for fellow gophers in New England. Meetups are held on the last Tuesday of each Month. 
+https://www.meetup.com/bostongo


### PR DESCRIPTION
## Your project

**1Password Teams url**: bostongolang.1password.com
**Project name**:  Boston Golang

**Short description**: 
> Boston Golang is a Boston based community for people working with the Go programming language to discuss ideas, issues and share solutions. Boston Golang held their first Meetup on October 21, 2014 and as of April 2020 the group counts more than 1,700 members. Boston Golang is the only community for fellow gophers in New England. Meetups are held on the last Tuesday of each Month. 

**Project age**:  First meetup held on October 2014

**Number of core contributors**: currently 3 active Organizers; 1700 members

**Project website**: https://www.meetup.com/bostongo

**Repository url**: Main activity happens via meetup. Though Boston Go has a less active GitHub org: https://github.com/bostongolang

**Latest release url**: Latest meetup happened via Zoom on 3/31/2020, https://www.meetup.com/bostongo/events/269353067/

**License type**: n/a since we are a meetup. We are open to all people interested in Go and do not collect fees for membership or attendance.

**License url**: n/a


## Tell us about yourself

**Name**: Bjoern Poetzschke

**Email**: bjoern.poetzschke@gmail.com

**Project role**: Co-organizer

**Website**: https://github.com/bpoetzschke
