### PR TITLE
Add Vancouver Go meetup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,3 +675,7 @@ https://go-gilbert.github.io/
 A CNCF standard for defining how to add well-defined metadata to events for
 interop and automated tooling.
 https://cloudevents.io
+
+### Vancouver Go Meetup (London Gophers)
+The Vancouver Go Meetup is a Vancouver, Canada meetup group for anyone interested in the Go programming language.
+https://www.meetup.com/golangvan/


### PR DESCRIPTION
Adding the Vancouver Go Meetup group.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

## Your project

**1Password Teams url**:https://vancouvergomeetup.1password.com/

**Project name**:  Vancouver Go Meetup

**Short description**: A meetup group in Vancouver Canada for the Go programming language

**Project age**: ~6 years, first meetup was Feb 2014

**Number of core contributors**: 4

**Project website**: https://www.meetup.com/golangvan/

**Repository url**: n/a

**Latest release url**: n/a

**License type**: n/a 

**License url**: n/a


## Tell us about yourself

**Name**:  Callum Styan

**Email**: callumstyan@gmail.com

**Project role**: meetup organizer

**Website**: https://github.com/cstyan
