### PR TITLE
README.md: add the perl foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,3 +738,8 @@ https://github.com/adeepak7/CCDSAP-Roadmap
 ### ClimateAction.tech
 We are a global community of tech professionals using our skills, expertise and platforms to support solutions to the climate crisis.
 https://climateaction.tech/
+
+### Perl
+
+The Perl Foundation is dedicated to the advancement of the Perl and Raku programming languages through open discussion, collaboration, design, and code.  Perl is a popular dynamic programming language, and Raku is the next language in the Perl family of programming languages.
+https://www.perlfoundation.org/


### PR DESCRIPTION
## The Perl Foundation

**1Password Teams url**: perlfoundation.1password.com

**Project name**:  Perl (via The Perl Foundation)

**Short description**: The Perl Foundation is the non-profit organization dedicated to furthering the Perl family of programming languages

**Project age**: 32 years

**Number of core contributors**: 46

**Project website**: https://www.perlfoundation.org/

**Repository url**: https://github.com/Perl/perl5

**Latest release url**: https://metacpan.org/release/XSAWYERX/perl-5.32.0

**License type**: dual: GPL and Artistic 1.0

**License url**: https://github.com/Perl/perl5/blob/blead/Artistic and https://github.com/Perl/perl5/blob/blead/Copying


## Tell us about yourself

**Name**:  Ricardo Signes

**Email**: rjbs@perlfoundation.org

**Project role**: member, board of directors, Perl Foundation; former project manager (2011-2015), perl5

**Website**: https://github.com/rjbs/