### PR TITLE
Add FlaggyFlag to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,3 +895,7 @@ https://random.icu
 ### Vaken
 [Vaken](https://github.com/vandyhacks/vaken) is a hackathon management system featuring hacker registration, applications, NFC, event management, and sponsor management developed by [VandyHacks, the hackathon organization at Vanderbilt University](https://vandyhacks.org/).
 https://vandyhacks.org/
+
+### FlaggyFlag
+FlaggyFlag is setup to output calendar (.ics) file to see what flag (royal normal/banner/half-mast) needs to be flown on which day. Personalised per country.
+https://github.com/walgemoed/FlaggyFlag


### PR DESCRIPTION
1Password Teams url: flaggyflag.1password.com

Project name: FlaggyFlag

Short description: FlaggyFlag is setup to output calendar (.ics) file to see what flag (royal normal/banner/half-mast) needs to be flown on which day. Personalised per country.

Project age: 2 years

Number of core contributors: 2 – this will increase with one or two in the coming months

Project website: https://github.com/walgemoed/FlaggyFlag

Repository url: https://github.com/walgemoed/FlaggyFlag

Latest release url: project is in beta at this time

License type: MIT

License url: https://github.com/walgemoed/FlaggyFlag/blob/master/LICENSE

Tell us about yourself
Name: Henk Walgemoed

Email: henk at walgemoed.com

Project role: Developer

Website: https://github.com/walgemoed