### PR TITLE
Add Front Conference Zurich

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,3 +895,7 @@ https://random.icu
 ### Vaken
 [Vaken](https://github.com/vandyhacks/vaken) is a hackathon management system featuring hacker registration, applications, NFC, event management, and sponsor management developed by [VandyHacks, the hackathon organization at Vanderbilt University](https://vandyhacks.org/).
 https://vandyhacks.org/
+
+### Front Conference Zurich
+Front Conference Zurich is a non-profit conference targeting Designers & Frontend engineers taking place yearly in Zurich. As a not-for-profit community event we rely on volunteers to enable us to run a great event.
+https://frontconference.com/


### PR DESCRIPTION
## Your project

**1Password Teams url**: myteam.1password.com (create the account before applying).
https://frontzurich.1password.com/

**Project name**:  Front Conference Zurich (Short: Front Zurich)

**Short description**: Front Conference Zurich is a non-profit conference targeting Designers & Frontend engineers taking place yearly in Zurich. As a not-for-profit community event we rely on volunteers to enable us to run a great event.

**Project age**: 10years+

**Number of core contributors**: 9

**Project website**: https://frontconference.com/

**Repository url**: https://github.com/frontendconf

**Latest release url**: https://frontconference.com/

**License type**: –

**License url**: –


## Tell us about yourself

**Name**: Sascha Eggenberger

**Email**: sascha@frontendconf.ch

**Project role**: Workspace Admin

**Website**: https://frontconference.com/
