### PR TITLE
Add Dj-Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,7 +1148,7 @@ By providing frameworks and reference implementations, LF Energy minimizes pain 
 https://lfenergy.org
 
 ### GDPR WP
-Simple plugin to load tracking scripts based on user consent. No dark patterns.  
+Simple plugin to load tracking scripts based on user consent. No dark patterns.
 https://wordpress.org/plugins/og-gdpr/
 
 ### FIPost
@@ -1174,3 +1174,7 @@ https://github.com/dotiful/vscode-dotfiles-syntax
 ### Hack the 6ix
 Hack the 6ix is the largest student-run, non-for-profit summer hackathon located in the hear of Toronto.
 https://hackthe6ix.com
+
+### Dj-Stripe
+A Django library to integrate with the Stripe API and process Stripe webhooks.
+https://github.com/dj-stripe/dj-stripe


### PR DESCRIPTION
## Dj-Stripe ##

#### 1Password Teams URL ####
<!-- dj-stripe.1password.com -->

#### Project Name ####
dj-stripe

#### Short Description ####
Django + Stripe made easy. Dj-Stripe is a library that implements Stripe models for Django and eases integration with their API and webhooks.

#### Project Age ####
6 years

#### Number Of Core Contributors ####
3-5

#### Project Website ####
https://github.com/dj-stripe/dj-stripe | https://dj-stripe.dev (inactive at the moment)

#### Repository URL(s) ####
https://github.com/dj-stripe/dj-stripe

#### Latest Release URL(s) ####
https://github.com/dj-stripe/dj-stripe/releases/tag/2.5.0

#### License Type ####
MIT

#### License URL ####
https://github.com/dj-stripe/dj-stripe/blob/master/LICENSE

## A Bit About Yourself  ##

#### Name ####
Jerome Leclanche

#### Email ####
<jerome@leclan.ch>

#### Project Role ####
Project maintainer

#### Profile/Website ####
https://leclan.ch

#### Comments ####
Happy user of 1Password already, we'd like to use it to store and share various API keys more securely :)