### PR TITLE
Update Raku, renamed from Perl 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,9 @@ https://github.com/iglance/iGlance
 An extension for the Visual Studio Code editor that allows you to highlight trailing spaces and delete them in a flash!
 https://github.com/shardulm94/vscode-trailingspaces
 
-### Perl 6
-[Perl 6](https://perl6.org) is a multi paradigm programming language. It's completely community-driven.
-https://github.com/perl6
+### Raku
+[Raku](https://raku.org) is a multi paradigm programming language. It's completely community-driven. (Renamed from Perl 6)
+https://github.com/raku
 
 ### osquery
 [osquery](https://osquery.io) provides SQL powered operating system instrumentation, monitoring, and analytics.


### PR DESCRIPTION
## Your Project ##
This is an update for the rename of Perl 6 -> Raku. We have a team-raku URL already.
Would you be so kind to extend it for another year? Separate email sent.

#### 1Password Teams URL ####
https://team-raku.1password.com/

#### Project Name ####
Raku

#### Short Description ####
Raku is a multi paradigm programming language.

#### Project Age ####
Since 2000

#### Number Of Core Contributors ####
50 regular contributors for Raku, NQP, Rakudo (compiler) and MoarVM (virtual machine)

#### Project Website ####
https://raku.org

#### Repository URL(s) ####
https://raku.org/

#### Latest Release URL(s) ####
https://github.com/rakudo/rakudo/tree/master/docs/announce
https://rakudo.org/downloads

#### License Type ####
GNU General Public License or Artistic License 2

#### License URL ####
https://en.wikipedia.org/wiki/GNU_General_Public_License
https://en.wikipedia.org/wiki/Artistic_License

## A Bit About Yourself  ##

#### Name ####
Roman Baumer

#### Email ####
roman@baumer-its.ch

#### Project Role ####
Infrastructure Manager / SME for Raku (including NQP, Rakudo and MoarVM)
see: @rba https://github.com/raku/problem-solving#labels-and-responsible-devs

#### Profile/Website ####
https://github.com/rba

#### Comments ####
Thank you for supporting the community!