### PR TITLE
Add Black Magic Lab's Surge Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,3 +1265,7 @@ https://github.com/xpyxel/spring
 ### vue-notion
 Build open-source tools around Notion and Vue.
 https://github.com/janniks/vue-notion
+
+### Black Magic's Surge Modules
+A set of iOS surge application modules, including automatic scripts, cronjobs, panels and more. 
+https://github.com/Black-Magic-Lab/Surge


### PR DESCRIPTION
## Black Magic Lab's Surge Modules ##

#### 1Password Teams URL ####
https://blackmagiclab.1password.com/

#### Project Name ####
Black Magic Lab's Surge Modules

#### Short Description ####
A set of iOS surge application modules, including automatic scripts, cronjobs, panels and more. 

#### Project Age ####
More than 1 year but uploaded to GitHub in 1 month.

#### Number Of Core Contributors ####
6

#### Project Website ####
https://github.com/Black-Magic-Lab/Surge

#### Repository URL(s) ####
https://github.com/Black-Magic-Lab/Surge

#### Latest Release URL(s) ####
https://github.com/Black-Magic-Lab/Surge/Release

#### License Type ####
MIT

#### License URL ####
https://github.com/Black-Magic-Lab/Surge/blob/master/LICENSE


## A Bit About Yourself  ##

I'm an iOS developer. I created Black Magic Lab with my colleagues and friends and we focus on security testing, reverse engineering and other stuff we are interested in.

#### Name ####
Hiraku Wang

#### Email ####
dev#hiraku.tw

#### Project Role ####
Owner, Core Dev

#### Profile/Website ####
https://github.com/hirakujira
https://hiraku.tw

#### Comments ####
