### PR TITLE
Add JUnit Pioneer

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,10 +904,6 @@ https://vandyhacks.org/
 AssertJ is a library providing easy to use rich typed assertions.
 https://github.com/assertj
 
-### JUnit Pioneer
-JUnit Pioneer provides extensions for JUnit 5 and its Jupiter API.
-https://junit-pioneer.org
-
 ### FlaggyFlag
 FlaggyFlag is setup to output calendar (.ics) file to see what flag (royal normal/banner/half-mast) needs to be flown on which day. Personalised per country.
 https://github.com/walgemoed/FlaggyFlag
@@ -1367,3 +1363,7 @@ https://github.com/P-404
 ### Roguelike Celebration
 An annual conference celebrating roguelike games, procedural generation, and the history of computing. Virtual editions of our conference are hosted in our own open-source [game-like event platform and social space](https://github.com/lazerwalker/azure-mud).
 https://roguelike.club
+
+### JUnit Pioneer
+JUnit Pioneer provides extensions for JUnit 5 and its Jupiter API.
+https://junit-pioneer.org

--- a/README.md
+++ b/README.md
@@ -904,6 +904,10 @@ https://vandyhacks.org/
 AssertJ is a library providing easy to use rich typed assertions.
 https://github.com/assertj
 
+### JUnit Pioneer
+JUnit Pioneer provides extensions for JUnit 5 and its Jupiter API.
+https://junit-pioneer.org
+
 ### FlaggyFlag
 FlaggyFlag is setup to output calendar (.ics) file to see what flag (royal normal/banner/half-mast) needs to be flown on which day. Personalised per country.
 https://github.com/walgemoed/FlaggyFlag


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://junitpioneer.1password.com

#### Project Name ####
JUnit Pioneer

#### Short Description ####
JUnit Pioneer provides extensions for [JUnit 5](https://github.com/junit-team/junit5/) and its Jupiter API.
It does not limit itself to proven ideas with wide application but is purposely open to experiments.
It aims to spin off successful and cohesive portions into sibling projects or back into the JUnit 5 code base.

#### Project Age ####
2016

#### Number Of Core Contributors ####
5

#### Project Website ####
https://junit-pioneer.org

#### Repository URL(s) ####
https://github.com/junit-pioneer/junit-pioneer

#### Latest Release URL(s) ####
https://github.com/junit-pioneer/junit-pioneer/releases/tag/v1.5.0

#### License Type ####
Eclipse Public License (EPL) 2.0

#### License URL ####
https://github.com/junit-pioneer/junit-pioneer/blob/main/LICENSE.md


## A Bit About Yourself  ##

#### Name ####
Daniel Kraus

#### Email ####
`daniel<DOT>kraus<AT>mailbox<DOT>org`

#### Project Role ####
Maintainer

#### Profile/Website ####
https://github.com/beatngu13

#### Comments ####
Added JUnit Pioneer below AssertJ since both projects target testing on the JVM / with Java.
