### PR TITLE
Add Send-to-Telegram for Google Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,3 +1379,8 @@ https://www.metadocencia.org
 ### CashWarden
 An open source financial management system.
 https://github.com/cashwarden
+
+### Send-to-Telegram for Google Chrome
+A Chrome extension that allow you to send web content (tab, text, image) to your own "Telegram Bot" using official Telegram API.
+https://chrome.google.com/webstore/detail/send-to-telegram-for-goog/dgblfklicldlbclahclbkeiacpiiancc
+


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://team-nuaa.1password.com

#### Project Name ####
Send-to-Telegram for Google Chrome

#### Short Description ####
A Chrome extension that allow you to send web content (tab, text, image) to your own "Telegram Bot" using official Telegram API.

#### Project Age ####
8 months

#### Number Of Core Contributors ####
1

#### Project Website ####
https://chrome.google.com/webstore/detail/send-to-telegram-for-goog/dgblfklicldlbclahclbkeiacpiiancc

#### Repository URL(s) ####
https://github.com/phguo/Send-to-Telegram-Chrome-extension

#### Latest Release URL(s) ####
https://github.com/phguo/Send-to-Telegram-Chrome-extension/releases

#### License Type ####
MIT License

#### License URL ####
https://github.com/phguo/Send-to-Telegram-Chrome-extension/blob/master/LICENSE

## A Bit About Yourself  ##

#### Name ####
Penghui Guo

#### Email ####
m AT guo DOT ph

#### Project Role ####
Core developer

#### Profile/Website ####
https://github.com/phguo

#### Comments ####
