### PR TITLE
Add Jenkins to the list of open source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1414,3 +1414,7 @@ https://github.com/jhaals/yopass
 The [Precision Health Informatics Data Lab](https://phidatalab.org/) is an academic research group, spanning [King’s College London](https://www.kcl.ac.uk/), [University College London](https://www.ucl.ac.uk/), and the National Institute for Health Research Maudsley Biomedical Research Centre ([NIHR Maudsley BRC](https://maudsleybrc.nihr.ac.uk/)).
 We develop a number of open source code bases, including the [RADAR-base](https://radar-base.org/) open source platform to leverage data from wearables and mobile technologies. 
 https://phidatalab.org/
+
+### Jenkins
+An open source automation server which enables developers around the world to reliably build, test, and deploy their software
+https://www.jenkins.io


### PR DESCRIPTION
## Your Project ##

Jenkins

#### 1Password Teams URL ####

https://jenkins-team.1password.com

#### Project Name ####

Jenkins

#### Short Description ####

The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.

#### Project Age ####

Jenkins -  2 February 2011
Hudson - 7 February 2005

#### Number Of Core Contributors ####

Its really hard to say, there's been more than 600 contributors to the core project, and many people like me that work on infra or plugins.

#### Project Website ####

https://www.jenkins.io

#### Repository URL(s) ####

https://github.com/jenkinsci/jenkins/

#### Latest Release URL(s) ####

https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.324

#### License Type ####

MIT

#### License URL ####

https://opensource.org/licenses/MIT

## A Bit About Yourself  ##

#### Name ####

Gavin Mogan

#### Email ####

1password@gavinmogan.com

#### Project Role ####

Governance Board Member, plugin site owner, and infra contributor

#### Profile/Website ####

https://github.com/halkeye/ / https://www.gavinmogan.com

#### Comments ####
