### PR TITLE
Add Jupyter as 1Password users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,10 @@ https://github.com/raku
 ### NumFOCUS
 [NumFOCUS](https://numfocus.org) provides a stable, independent, and professional home for the [open source projects](https://numfocus.org/sponsored-projects) powering contemporary scientific inquiry and business processes. We aim to ensure that funding and resources are available to sustain projects in the scientific data stack over the long haul.
 
+### Jupyter
+
+[Jupyter](https://jupyter.org) is a project and community whose goal is to develop open-source software, open-standards, and services for interactive computing across dozens of programming languages.
+
 ### NUSMods
 [NUSMods](https://nusmods.com) is a student maintained course catalogue, module search and timetable builder for the National University of Singapore.
 


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####

https://jupyter.1password.com/home

#### Project Name ####

Jupyter

#### Short Description ####

The Jupyter Project is a project and community whose goal is to
"develop open-source software, open-standards, and services for
interactive computing across dozens of programming languages"

#### Project Age ####

7 Years old (created in 2015)

#### Number Of Core Contributors ####

Current Steering council is 17 members (as per
https://jupyter.org/about), the definition of core contributors is a bit
more fuzzy and there are likely a few dozen with all the repos we
manage.

#### Project Website ####

https://jupyter.org

#### Repository URL(s) ####

https://github.com/jupyter
https://github.com/jupyterhub
https://github.com/jupyterlab
https://github.com/ipython/

#### Latest Release URL(s) ####

https://pypi.org/project/jupyterlab/
https://pypi.org/project/notebook
https://pypi.org/project/ipython
https://pypi.org/project/ipykernel

#### License Type ####

BSD

#### License URL ####

https://github.com/jupyterlab/jupyterlab/blob/master/LICENSE

## A Bit About Yourself  ##

#### Name ####

Matthias Bussonnier

#### Email ####

bussonniermatthias@gmail.com

#### Project Role ####

Steering Council Member and Founder of the Jupyter Project since before
it's inception (2012), I'm currently trying to push a bit for better
security practices and credential managements.

#### Profile/Website ####

You can find some of my rambling on https://matthiasbussonnier.com/,
otherwise most of my activity is on github https://github.com/carreau
and on twitter (https://twitter.com/mbussonn)

#### Comments ####

I'm personally not a 1password users, but I heard good things, the
current solution seem to be a bit inadequate as there is a keepassc
credential file shared via dropbox which is super problematic.

My hope is to make it easier to share sensitive credentials to the core
security/admins, that is everything that does not support account
delegation. Currently the main struggle we have are with:
 - Hosting providers that do not support delegation.
 - Twitter (and indirectly via twitter: medium)
 - Some website like readthedocs,
 - the original credentials of some shared accounts (like Gmail, where
   folks are delegated but every now and then need access to them).

We'll likely also store there a few rarely access personal credential in
case of a catastrophe.

I hope that the group structure of 1password will help us to manage who
needs access to what (website/social-media/communication), but as stated
above I don't have much one-password experience.

Side personal note, I really appreciate your team putting out technical
blogs out, like the recent 1password for linux using rust.

Thanks,