### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,3 +1476,8 @@ https://github.com/gestaltjs
 ### notion-enhancer
 an enhancer/customiser for the all-in-one productivity workspace notion.so
 https://notion-enhancer.github.io/
+
+
+### Network Share Mounter
+Network Share Mounter is a macOS utility to perform automatic network share mounts. It has arisen from the need of our users at the university to automatically mount department/usergroup specific SMB shares.    
+https://gitlab.rrze.fau.de/faumac/networkShareMounter


### PR DESCRIPTION
Added Network Share Mounter for macOS

## Your Project ##
Network Share Mounter

#### 1Password Teams URL ####
https://faumac.1password.eu

#### Project Name ####
Network Share Mounter

#### Short Description ####
macOS utility to automatically mount user or MDM defined SMB shares if network resources are available. it's a little bit like Unix' automounter

#### Project Age ####
4 Years

#### Number Of Core Contributors ####
3

#### Project Website ####
https://gitlab.rrze.fau.de/faumac/networkShareMounter

#### Repository URL(s) ####
https://gitlab.rrze.fau.de/faumac/networkShareMounter

#### Latest Release URL(s) ####
https://gitlab.rrze.fau.de/faumac/networkShareMounter/-/releases

#### License Type ####
MIT

#### License URL ####
https://gitlab.rrze.fau.de/faumac/networkShareMounter/-/blob/dev/LICENSE

## A Bit About Yourself  ##
I am the team lead for Apple Device Support Team (FAUmac Team) at the computational center of the university of Erlangen-Nürnberg. We provide all sorts of tools for all kind of Apple devices ate the university.   

#### Name ####
Gregor Longariva

#### Email ####
Gregor.longariva@fau.de

#### Project Role ####
Team Lead, Developer

#### Profile/Website ####
https://twitter.com/anfalas
https://keybase.io/anfalas
https://github.com/anfalas


#### Comments ####
