### PR TITLE
Add open source: Network info - MacAddress via NetworkInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1536,3 +1536,7 @@ https://github.com/nhymxu/cf-dns-update-python
 ### ZaDark – Best Dark Theme for Zalo
 ZaDark helps you turn on Dark Theme for Zalo, making your eyes feel comfortable when you work, especially at night.
 https://github.com/ncdai3651408/za-dark
+
+### Network info - MAC Address via NetworkInterface
+Open-source check info network, mac Address details. Java implemented.
+https://github.com/vnn7298/Info_Network


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://team-vnn.1password.com

#### Project Name ####
Network info - MacAddress via NetworkInterface
#### Short Description ####
Open-source check info network, mac Address details. Java implemented
#### Project Age ####
2 months
#### Number Of Core Contributors ####
1
#### Repository URL(s) ####
https://github.com/vnn7298/Info_Network
#### Latest Release URL(s) ####
https://github.com/vnn7298/Info_Network/releases/tag/v1.0.1
#### License Type ####
[MIT License](https://github.com/vnn7298/Info_Network/blob/main/LICENSE)

#### License URL ####
https://github.com/vnn7298/Info_Network/blob/main/LICENSE


## A Bit About Yourself  ##
I am a developer, learning and researching on system and network security. This project I wrote about 2 months ago and I hope this project will help developers, users and everyone support.

#### Name ####
Van Nguyen Nam
#### Email ####
vnn7298@gmail.com
#### Project Role ####
Owner
#### Profile/Website ####
https://github.com/vnn7298

#### Comments ####
Thank you 1Passwords team, I feel very interested and want to explore more deeply and hope to contribute to 1Password's development more and more.