### PR TITLE
Add WePublish Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1556,3 +1556,7 @@ https://github.com/vnn7298/Info_Network
 ### OTP Firebase Twilio
 Create user, request OTP, get OTP through firebase platform
 https://github.com/hungvmtnfl/OTP-Firebase-Twilio
+
+### WePublish
+Open digital platform and infrastructure for Swiss media.
+https://wepublish.ch/


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
wepublish.1password.com

#### Project Name ####
We.Publish

#### Short Description ####
We.Publish is the new digital infrastructure of the Swiss media landscape where journalistic media/publishers can create and present their articles with intensive networking possibilities. As a foundation, the We.Publish Foundation promotes independent journalistic offerings and media diversity in Switzerland.

#### Project Age ####
since summer 2019

#### Number Of Core Contributors ####
7

#### Project Website ####
https://wepublish.ch/

#### Repository URL(s) ####
https://github.com/wepublish/wepublish
git@github.com:wepublish/wepublish.git

#### Latest Release URL(s) ####
https://editor.demo.wepublish.media/
https://api.demo.wepublish.media/

#### License Type ####
MIT

#### License URL ####
https://github.com/wepublish/wepublish/blob/master/LICENSE

## A Bit About Yourself  ##

#### Name ####
Tomasz Durka

#### Email ####
tomasz@wepublish.ch

#### Project Role ####
Dev Team Lead

#### Profile/Website ####
https://github.com/wepublish

#### Comments ####
We intend to use 1password for our development team which consists of about 5 devs right now. We need 1password for sharing credentials used for our dev process - k8s clusters, db accesses, gcloud keys, dev env payment providers. We create only open-source projects gathered under https://github.com/wepublish organisation. Our main project is wepublish platform - a cms for publishers and newsrooms. Currently most of our users are from Switzerland where we are located, but platform can be used worldwide in future.