### PR TITLE
Adding JSConf.cl to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1556,3 +1556,7 @@ https://github.com/vnn7298/Info_Network
 ### OTP Firebase Twilio
 Create user, request OTP, get OTP through firebase platform
 https://github.com/hungvmtnfl/OTP-Firebase-Twilio
+
+### JSConf Chile
+We are the JSconf.cl team, we are on a mission to help the Javascript community in Chile.
+https://jsconf.cl


### PR DESCRIPTION
Hey folks, just saw repo searching for ways we could safely share access to our accounts now that we are re-starting the work for this year's JSConf.cl.

## Your Project ##


#### 1Password Teams URL ####
https://jsconfcl.1password.com

#### Project Name ####
JSConf Chile

#### Short Description ####

JSconf.cl is the first JS conference we are running in Chile. (Our initial idea was to run this by 2020, but covid had other plans).
We are running the conference without looking to profit, and we want to keep it by-the-community, for-the-community. Our plan is to do one every year, and make the opensource the organization process so more folks can create their own conference.

#### Project Age ####

3 years

#### Number Of Core Contributors ####
6

#### Project Website ####
https://jsconf.cl/

#### Repository URL(s) ####
https://github.com/JSConfCL?type=source

#### Latest Release URL(s) ####
We don't really have one. (but 2022 if all goes well 😄)

#### License Type ####
[CC BY-SA](https://guides.lib.umich.edu/creativecommons/licenses#:~:text=Attribution%3A%20CC%20BY,and%20use%20of%20licensed%20materials.)

#### License URL ####
we don't have one yet, though our plan is to share the documentation process under said license

## A Bit About Yourself  ##

#### Name ####
Felipe Torres 

#### Email ####
felipe.torrressepulveda@gmail.com
(Or hi@fforr.es)

#### Project Role ####
Organizer - Core Team member

#### Profile/Website ####
- https://twitter.com/fforres
- https://github.com/fforres
- https://fforr.es/

#### Comments ####
I personally think this is a great idea! Supporting open-source projects with access to a great tool. Thank you 1Password team. 🙏