### PR TITLE
Add Ubuntu Korea Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,3 +1572,7 @@ https://jsconf.cl
 ### ESP32_LED
 Control LED RBG with ESP32 Internet of Thing
 https://github.com/cogn99/ESP32_LED
+
+### Ubuntu Korea Community
+Ubuntu Korea Community is a South Korea based Ubuntu Linux User and Contributor community for anyone interested in Ubuntu and its related FOSS projects. We organize local Ubuntu meetup and workshop events, Provide online space for Korean Ubuntu users. We also contribute on localization of Ubuntu's UI and documentation, and host our own open source projects such as [Hanjp Input Method](https://github.com/hanjp-im). As a verified Ubuntu Local community, We also collaborate with nearby foreign local communities such as Japan, Taiwan, China and more.
+https://ubuntu-kr.org


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
[ubuntu-kr.1password.com](https://ubuntu-kr.1password.com/)

#### Project Name ####
Ubuntu Korea Community

#### Short Description ####
A Ubuntu user and contributor community based on South Korea. Organizes local ubuntu events and provides online spaces for Korean Ubuntu users. Also contribute on localization of UI and documentation of Ubuntu.

[Detailed description on our website](https://ubuntu-kr.org/en/about/)

#### Project Age ####
Since 2005

#### Number Of Core Contributors ####
10 Organizers
(10K+ Members)

#### Project Website ####
https://ubuntu-kr.org
(Mostly active on Facebook group https://fb.com/groups/ubuntu-ko and IRC Libera.chat #ubuntu-ko)

#### Repository URL(s) ####
https://github.com/ubuntu-kr
https://launchpad.net/~ubuntu-ko

#### Latest Release URL(s) ####
Attaching our event website instead
https://event.ubuntu-kr.org/

#### License Type ####
Usually Websites uses MIT, Website contents uses CC BY-SA 4.0
And many other different licensed used by Translation, documentation, Korean community hosted projects and more.

#### License URL ####
N/A


## A Bit About Yourself  ##

#### Name ####
Youngbin Han
#### Email ####
sukso96100@gmail.com
#### Project Role ####
Leader/Community Organizer
#### Profile/Website ####
https://github.com/sukso96100
https://launchpad.net/~sukso96100

#### Comments ####
We've been managing our password and secrets that used to manage our infrastructure on Google sheet. I think 1Password's support will be a lot of help for us to manage our secrets in much more secure way.