### PR TITLE
Add CCExtractor Development to org list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1618,3 +1618,8 @@ https://laravel.io
 HackMcGill is McGill University's largest hacker collective. We annually run McGill University's largest hackathon to help empower students with technology.
 https://www.mchacks.ca
 http://github.com/hackmcgill
+
+### CCExtractor Development
+CCExtractor is the de-facto open source tool for anything related to closed captions and subtitles on broadcast media. CCExtractor Development maintains it and is also engaged in many other open source activities.
+https://www.ccextractor.org
+https://github.com/CCExtractor


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://ccextractordevelopment.1password.com

#### Project Name ####
CCExtractor Development

#### Short Description ####
CCExtractor is the de-facto open source tool for anything related to closed captions and subtitles on broadcast media. CCExtractor Development maintains it and is also engaged in many other open source activities.

#### Project Age ####
13 years

#### Number Of Core Contributors ####
6-7 that have been around since the very beginning or close, but since we participate in Google Summer of Code every year we get lots of "seasonal" contributors.

#### Project Website ####
https://ccextractor.org/

#### Repository URL(s) ####
https://github.com/CCExtractor

#### Latest Release URL(s) ####
For our core tool
https://github.com/CCExtractor/ccextractor/releases/tag/v0.94

But we have other things going on with different releases

#### License Type ####
GPL

#### License URL ####
https://github.com/CCExtractor/ccextractor/blob/master/LICENSE.txt

## A Bit About Yourself  ##
Software Engineer since forever

#### Name ####
Carlos F. Sanz

#### Email ####
carlos at ccextractor d o t o-r-g

#### Project Role ####
Original author, now maintainer, team builder (well, sort of) and in charge of administrative BS.

#### Profile/Website ####
https://github.com/orgs/CCExtractor/people/cfsmp3

#### Comments ####
I do have my own family account, but it will be nice to have something for the team as well.
