### PR TITLE
Add GoogleTranslate PopClip Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1632,3 +1632,7 @@ https://github.com/CCExtractor
 ### casper2020
 Several different tools from nginx modules to standalone psql database migration (nando)
 https://github.com/casper2020
+
+### GoogleTranslate PopClip Extension
+[GoogleTranslate PopClip Extension](https://github.com/wizyoung/googletranslate.popclipext) is an unofficial free Google translate Extension for the macOS app PopClip.
+https://github.com/wizyoung/googletranslate.popclipext


### PR DESCRIPTION
## GoogleTranslate PopClip Extension ##

#### 1Password Teams URL ####
https://team-wizz.1password.com

#### Project Name ####
[googletranslate.popclipext](https://github.com/wizyoung/googletranslate.popclipext)

#### Short Description ####
An unofficial free Google translate Extension for macOS app PopClip.

#### Project Age ####
4 years 7 months.

#### Number Of Core Contributors ####
1 (myself)

#### Project Website ####
https://github.com/wizyoung/googletranslate.popclipext

#### Repository URL(s) ####
https://github.com/wizyoung/googletranslate.popclipext

#### Latest Release URL(s) ####
https://github.com/wizyoung/googletranslate.popclipext/releases/tag/v3.1

#### License Type ####
MIT.

#### License URL ####
https://github.com/wizyoung/googletranslate.popclipext/blob/master/LICENSE


## A Bit About Yourself  ##

#### Name ####
Wizyoung

#### Email ####
happyyanghehe@gmail.com

#### Project Role ####
Creator and the only maintainer.

#### Profile/Website ####
Github profile page: https://github.com/wizyoung

Personal website: https://wizyoung.dogcraft.xyz/

#### Comments ####

