### PR TITLE
Add Typed Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,3 +1688,7 @@ https://github.com/FrontLabsOfficial/vue-tiny-validate
 ### Typelevel
 Typelevel is an association of projects and individuals united to foster an inclusive, welcoming, and safe environment around functional programming in Scala.
 https://typelevel.org
+
+### Typed Settings
+Safe and flexible settings in Python: Structure and validate your settings with attrs classes and load them from any source (e.g., env vars, config files, CLI options, 1Password, …).
+https://typed-settings.readthedocs.io


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://team-typedsettings.1password.com

#### Project Name ####

Typed Settings

#### Short Description ####

Safe and flexible settings in Python: Structure and validate your settings with attrs classes and load them from any source (e.g., env vars, config files, CLI options, 1Password, …).

#### Project Age ####

Aug 27, 2020

#### Number Of Core Contributors ####

2

#### Project Website ####

https://typed-settings.readthedocs.io

#### Repository URL(s) ####

https://gitlab.com/sscherfke/typed-settings

#### Latest Release URL(s) ####

https://pypi.org/project/typed-settings/1.0.1/

#### License Type ####

MIT

#### License URL ####

https://gitlab.com/sscherfke/typed-settings/-/blob/main/LICENSE

## A Bit About Yourself  ##

#### Name ####

Stefan Scherfke

#### Email ####

`stefan+typed-settings at sofa-rockers.org`

#### Project Role ####

Author and Maintainer

#### Profile/Website ####

- stefan.sofa-rockers.org
- github.com/sscherfke
- gitlab.com/sscherfke

#### Comments ####

I want to add a 1Password backend/loader to Typed Settings and thus want to use `op` in the CI/CD pipeline.

Here is a video and screenshot of the PoC: https://twitter.com/sscherfke/status/1505534217123512327?s=20&t=4fhMfWPuID_IZiRZZH5DZQ

And the corresponding code: https://gitlab.com/sscherfke/typed-settings/-/blob/one-password/src/typed_settings/loaders.py#L167-187