### PR TITLE
Add Washtenaw ID Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,3 +1749,8 @@ https://kyverno.io/
 ### SpeechToText
 Open speech to text written in Pthon with tensorflow.
 https://github.com/djactor/SpeechToText.git
+
+### Washtenaw ID Project
+The Washtenaw ID Project is a non-profit organization based in Washtenaw County, Michigan that seeks to ensure that all residents of Washtenaw County have meaningful access to a government-issued ID that validates their identity and residency. We are building a web app to help people find businesses that actively support the ID and accept it as proof of identity.
+http://www.washtenawid.com/who-we-are/
+https://github.com/washtenawIdtreble?tab=repositories


### PR DESCRIPTION
## Your Project ##
Washtenaw ID Project
#### 1Password Teams URL ####
https://washtenawidproject.1password.com
#### Project Name ####
Washtenaw ID Project Business Access App
#### Short Description ####
The Washtenaw ID Project is a non-profit organization based in Washtenaw County, Michigan that seeks to ensure that all residents of Washtenaw County have meaningful access to a government-issued ID that validates their identity and residency. We are building a web app to help people find businesses that actively support the ID and accept it as proof of identity.
#### Project Age ####
2 months
#### Number Of Core Contributors ####
2
#### Project Website ####
http://www.washtenawid.com/who-we-are/ 
#### Repository URL(s) ####
https://github.com/washtenawIdtreble?tab=repositories
#### Latest Release URL(s) ####
https://washtenaw-id-webapp-dev.herokuapp.com/
#### License Type ####
GPL 3.0
#### License URL ####
https://github.com/washtenawIdtreble/washtenaw-id-webapp/blob/dev/LICENSE
## A Bit About Yourself  ##
I'm a software developer living in Ann Arbor, Michigan. I've been working as a software consultant for 6 years, where I had the opportunity to learn and grow through paired-programming with other professionals. As I've grown, I've looked for ways to use my skills for social good, including studying for certification in Web Accessibility. I connected with the Washtenaw ID Project several years ago, and organized several of my colleagues to build a resource for people in our community to find businesses that accept the Washtenaw County ID card. Our team and goals have shifted over time, and two months ago, my colleague Helen and I refocused our efforts on creating a simple web application to publish this information, with plans to expand it after we establish a foundation.
#### Name ####
Ryan Heisler
#### Email ####
ryan.a.heisler@gmail.com
#### Project Role ####
Lead developer and project manager
#### Profile/Website ####
http://www.ryanheisler.com/
https://github.com/lortimer
#### Comments ####
We would like to establish this 1Password so we can give control of the passwords to the Washtenaw ID Project itself instead of managing them for ourselves. This will allow us to give up control of the source code and web infrastructure if the ID Project ever wants to use other developers to work on the project.