### PR TITLE
docs: add OMShub to 1Password OSS teams list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1785,3 +1785,7 @@ A web-based password manager that runs 100% offline locally in your browser. It 
 types of password formats of passphrases, pseudowords, and random meaningless password strings,
 with incredible language support (30+ languages currently) and attention paid to verbal and visual
 ambiguity, memorability, error checking, and other features. https://github.com/atoponce/webpassgen
+
+### OMShub
+Open source collaboration for Georgia Tech Online Master of Science (OMS) Programs course reviews.
+https://myawesomeproject.org


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
omshub.1password.com

#### Project Name ####

OMShub

#### Short Description ####

Open source collaboration for Georgia Tech Online Master of Science (OMS) Programs course reviews

#### Project Age ####

< 30 days. I understand that 30 days is stated as the minimum, but we've achieved a lot in the ~10 days the project has been active and are in the middle of provisioning a lot of infrastructure that we'll need to manage accounts for. Access to 1Password Teams would be a huge boon for our security posture.

#### Number Of Core Contributors ####

Still in flux. Ballpark figure would be around a dozen.

#### Project Website ####

https://github.com/omshub

#### Repository URL(s) ####

- https://github.com/omshub/website
- https://github.com/omshub/public-record
- https://github.com/omshub/core-api

#### Latest Release URL(s) ####

https://omshub.org

#### License Type ####
GPL

#### License URL ####
<!-- A copy of the license terms and conditions for your software -->

- https://github.com/omshub/website/blob/main/LICENSE.md
- https://github.com/omshub/core-api/blob/main/LICENSE

## A Bit About Yourself  ##

#### Name ####

James Liu

#### Email ####

jliu998@gatech.edu

#### Project Role ####

Maintainer, back end and infrastructure.

#### Profile/Website ####

- https://github.com/disposedtrolley
- https://jamesliu.io

#### Comments ####

Thanks for your time in reviewing our application. We're younger than most projects that have applied for this previously, but we've gained a lot of momentum and have a lot of drive to stand up a community-run course reviews website for OMS degrees at Georgia Tech!