### PR TITLE
Updated readme: added OWASP WrongSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1885,3 +1885,7 @@ https://www.ruby-lang.org
 ### Climate Mind
 Powering climate conversations. It can be a real challenge to communicate the realities of climate change to people around you, especially those who have different values and personal interests. Often, people don’t realize actionable solutions already exist that don’t require an overhaul of their personality or beliefs. The [Climate Mind web app](https://climatemind.org) is a tool that makes meaningful conversations about climate change easier.
 https://github.com/ClimateMind
+
+### OWASP WrongSecrets
+OWASP WrongSecrets is an intentionally vulnerable app which learns you evertyhing about secrets management. It contains both a testbed to evaluate your secret scanner for secret detection, as well as many challenges which will teach you something about your own secrets management strategy. The vulnerable app is online available at a [free heroku instance](https://wrongsecrets.herokuapp.com/) and project sourcecode can be found at [the OWASP Project entry](https://github.com/OWASP/www-project-wrongsecrets). 
+https://github.com/commjoen/wrongsecrets


### PR DESCRIPTION
## Your Project ##
OWASP WrongSecrets

#### 1Password Teams URL ####
https://owasp.1password.com/home

#### Project Name ####
OWASP Wrongsecrets

#### Short Description ####
OWASP WrongSecrets is the first Secrets Management-focused vulnerable/p0wnable app! It can be used in security trainings, awareness demos, as a test environment for secret detection tools, and bad practice detection tooling.

#### Project Age ####
6 months

#### Number Of Core Contributors ####
3

#### Project Website ####
https://owasp.org/www-project-wrongsecrets/

#### Repository URL(s) ####
https://github.com/commjoen/wrongsecrets
https://github.com/commjoen/wrongsecrets-binarys
https://github.com/OWASP/www-project-wrongsecrets

#### Latest Release URL(s) ####
https://github.com/commjoen/wrongsecrets/releases

#### License Type ####
MIT

#### License URL ####
https://github.com/commjoen/wrongsecrets/blob/master/LICENSE

## A Bit About Yourself  ##
I am one of the 2 project leaders of OWASP WrongSecrets, before that I have been active in various OWASP Projects.

#### Name ####
Jeroen Willemsen

#### Email ####
jeroen.willemsen@owasp.org

#### Project Role ####
Proeject leader

#### Profile/Website ####
https://github.com/commjoen/

#### Comments ####
We would like to use this account to create a blocked user with a recovery package, which we then can commit to git so that secret scanners in git know where to look for to revoke this.
