### PR TITLE
docs: Add electron-info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1897,3 +1897,7 @@ https://github.com/commjoen/wrongsecrets
 ### Text-Image Encryptor
 An Open-source for securing your texts. This is a text-hiding tool. It allows to hide (and get back) text within a image. The output image can be normal used. The text can be encrypted with an password.
 https://github.com/mirepos/Text-Image-Encryptor
+
+### electron-info
+A CLI to retrieve useful data about Electron releases. Allows for detailed filtering of releases and dependency versions.
+https://github.com/ffflorian/electron-info


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
https://ffflorian.1password.eu

#### Project Name ####
electron-info

#### Short Description ####
A CLI to retrieve useful data about Electron releases.

#### Project Age ####
3 years

#### Number Of Core Contributors ####
1

#### Project Website ####
https://github.com/ffflorian/electron-info

#### Repository URL(s) ####
https://github.com/ffflorian/electron-info

#### Latest Release URL(s) ####
https://github.com/ffflorian/electron-info/releases

#### License Type ####
GPL-3.0

#### License URL ####
https://github.com/ffflorian/electron-info/blob/d8c97ca1f80325d20a543de5e9626eefedd7af9a/LICENSE


## A Bit About Yourself  ##

#### Name ####
Florian Imdahl

#### Email ####
hello@ffflorian.de

#### Project Role ####
Main contributor / developer

#### Profile/Website ####
https://github.com/ffflorian

#### Comments ####
Thank you very much for this project! Since I am using 1Password on a daily basis this helps me a lot!