### PR TITLE
Update README.md to add Sigstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2012,3 +2012,7 @@ https://github.com/vuhai16/textfromimage
 ### Rust Book Pdfs
 Up to date pdfs for learning Rust Language.
 https://github.com/shirshak55/Rust-Book-In-PDF
+
+### Sigstore
+Sigstore empowers software developers to securely sign software artifacts such as release files, container images, binaries, bill of material manifests and more. Signing materials are then stored in a tamper-resistant public log.
+https://sigstore.dev


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
sigstore.1password.com

#### Project Name ####
Sigstore

#### Short Description ####
Sigstore empowers software developers to securely sign software artifacts such as release files, container images, binaries, bill of material manifests and more. Signing materials are then stored in a tamper-resistant public log.

#### Project Age ####
1 year, 8 months

#### Number Of Core Contributors ####
40

#### Project Website ####
https://sigstore.dev

#### Repository URL(s) ####
https://www.github.com/sigstore/cosign
https://www.github.com/sigstore/rekor
https://www.github.com/sigstore/fulcio
https://www.github.com/sigstore/sigstore

Also many more in https://www.github.com/sigstore

#### Latest Release URL(s) ####

https://github.com/sigstore/cosign/releases/tag/v1.10.1
https://github.com/sigstore/rekor/releases/tag/v0.10.0
https://github.com/sigstore/fulcio/releases/tag/v0.5.2
https://github.com/sigstore/sigstore/releases/tag/v1.4.0

#### License Type ####
Apache License 2.0

#### License URL ####
https://github.com/sigstore/sigstore/blob/main/LICENSE

## A Bit About Yourself  ##

#### Name ####

Simon Kent

#### Email ####
simek@google.com
sdk@sigstore.dev

#### Project Role ####
Google Open Source Security team member working on the Sigstore General Available effort

#### Profile/Website ####
https://github.com/var-sdk

#### Comments ####
We plan to use 1password to secure some shared credentials for the Sigstore service.