### PR TITLE
adds Workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1997,6 +1997,10 @@ https://www.privacyguides.org/
 Script Anti-Ads OpenSource
 https://github.com/vnn7298/Script-Anti-Ads-OpenSource
 
+### workloads.io
+An open-source showcase of infrastructure-as-code workflows for multiple clouds and multiple types of workloads.
+https://github.com/workloads
+
 ### Gradience 
 Customize Adwaita with ease 
 https://github.com/AdwCustomizerTeam/AdwCustomizer 


### PR DESCRIPTION
## workloads.io ##

#### 1Password Teams URL ####

`workloads.1password.com`

#### Project Name ####

workloads.io - multi-cloud, multi-workload job orchestration workflows

#### Short Description ####

`workloads.io` is a collection of Terraform-based workflows to showcase Infrastructure as Code (IaC) approaches to multi-cloud, multi-workload job orchestration using HashiCorp Nomad.

#### Project Age ####

3-6 months

#### Number Of Core Contributors ####

2

#### Project Website ####

https://github.com/workloads/website

#### Repository URL(s) ####

https://github.com/workloads/

#### Latest Release URL(s) ####

see above

#### License Type ####

Apache 2.0, exclusively

#### License URL ####

https://github.com/workloads/.github/blob/main/LICENSE

## A Bit About Yourself  ##

@ksatirli is a senior developer advocate at @hashicorp, where he spends his time building out the Terraform community and showcasing best-practices around IaC workflows.

#### Name ####

Kerim Satirli

#### Email ####

`kerim at hashicorp`

#### Project Role ####

Creator

#### Profile/Website ####

https://github.com/ksatirli

#### Comments ####

Huge fan (and subscriber) of @1Password for personal (so much so that I have the "Early Beaver" badge) and professional usage. 

For @workloads, we use the 1Password CLI `op` to ease with the injection of _Secret Zero_ type data by shifting from an `.envrc` (with plaintext passwords) to a [workflow](https://github.com/workloads/workspaces/blob/main/Makefile#L47-L57) that doesn't result in credentials being stored in plain-text.

Access to a Team Account would help us keep project-specific credentials outside our personal and professional Vaults and will allow us to add other maintainers down the road.