### PR TITLE
add SeaGL (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2080,3 +2080,7 @@ https://web-scrobbler.com/
 ### action-slack
 action-slack is a product that notifies Slack from GitHub Actions.
 https://action-slack.netlify.app/
+
+### SeaGL - Seattle GNU Linux Conference
+Founded in 2013, SeaGL (the Seattle GNU/Linux Conference) is a free—as in freedom and tea—grassroots technical summit dedicated to spreading awareness and knowledge about free / libre / open source software, hardware, and culture. SeaGL strives to be welcoming, enjoyable, and informative for professional technologists, newcomers, enthusiasts, and all other users of free software, regardless of their background knowledge; providing a space to bridge these experiences and strengthen the free software movement through mentorship, collaboration, and community.
+https://seagl.org/


### PR DESCRIPTION
Adding SeaGL conference organization

## Your Project ##

SeaGL

#### 1Password Teams URL ####

seagl.1password.com

#### Project Name ####

SeaGL - Seattle GNU Linux Conference

#### Short Description ####

SeaGL is an annual GNU Linux conference held either in person, virtual or hybrid.

#### Project Age ####

10 years

#### Number Of Core Contributors ####

10 

#### Project Website ####

https://seagl.org 

#### Repository URL(s) ####

https://github.com/SeaGL

#### Latest Release URL(s) ####

n/a

#### License Type ####

GPL v3

#### License URL ####

https://github.com/SeaGL/seagl.github.io/blob/main/LICENSE

## A Bit About Yourself  ##

I'm one of two Tech/SRE co-chairs for this years event. I'm an open source enthusiast, and an SRE by trade.

#### Name ####

Don O'Neill

#### Email ####

sntxrr@seagl.org

#### Project Role ####

Tech/SRE committee co-chair. I take care of a lot of the technical behind-the-scenes things. Infrastructure for streaming, video uploads etc.

#### Profile/Website ####

https://github.com/sntxrr
https://gitlab.com/sntxrr
https://blog.sntxrr.dev

#### Comments ####

I'm a giant fan of 1password, I've been a family plan purchaser for years now, and I just don't have enough spare seats to share with the whole tech team. 
