### PR TITLE
Add Kanazawa.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2113,3 +2113,7 @@ https://github.com/nhatnguyen2410/w3band-frondend-project
 ### Database project management
 Distributed database material management
 https://github.com/nhatnguyen2410/QLVT
+
+### Kanazawa.js
+Kanazawa.js is a nonprofit community for anyone interested in JavaScript and Kanazawa based in Kanazawa, Ishikawa, Japan.
+https://github.com/kanazawa-js


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####

https://kanazawajs.1password.com/

#### Project Name ####

Kanazawa.js

#### Short Description ####

Kanazawa.js is a nonprofit community for anyone interested in JavaScript and Kanazawa based in Kanazawa, Ishikawa, Japan.

#### Project Age ####

2 years

#### Number Of Core Contributors ####

There are 3 core staffs.

#### Project Website ####

https://kanazawa-js.github.io/

#### Repository URL(s) ####

https://github.com/kanazawa-js

#### Latest Release URL(s) ####

NaN

#### License Type ####

NaN

#### License URL ####

NaN

## A Bit About Yourself  ##

#### Name ####

Yuki Minakawa

#### Email ####

kgr.ze21ro@gmail.com

#### Project Role ####

The chief organizer

#### Profile/Website ####

https://github.com/yu-kgr
https://kglabo.com/

#### Comments ####

Myself have been using 1Password for the past 6 years and find it very useful, so I would like to use 1Password in the Kanazawa.js community.