### PR TITLE
Add kanazawa rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -2645,7 +2645,7 @@ https://www.inreach.org
 
 ### Managyment
 
-Open source Gym nanagement system, we are working on new version rebuild in laravel and vuejs 
+Open source Gym nanagement system, we are working on new version rebuild in laravel and vuejs
 https://github.com/pechanxur/managyment
 
 ### BCN Engineering
@@ -2662,3 +2662,8 @@ https://www.wide.ad.jp/
 
 Python Community News is a podcast, livestream, and newsletter that focuses on the Non-Pipable news in the Python Community.
 https://pythoncommunitynews.com
+
+### Kanazawa.rb
+
+Kanazawa.rb is a nonprofit community for anyone interested in Ruby and Kanazawa based in Kanazawa, Ishikawa, Japan.
+https://github.com/kanazawarb

--- a/README.md
+++ b/README.md
@@ -2645,7 +2645,7 @@ https://www.inreach.org
 
 ### Managyment
 
-Open source Gym nanagement system, we are working on new version rebuild in laravel and vuejs
+Open source Gym nanagement system, we are working on new version rebuild in laravel and vuejs 
 https://github.com/pechanxur/managyment
 
 ### BCN Engineering


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####

https://kanazawarb.1password.com

#### Project Name ####

Kanazawa.rb

#### Short Description ####

Kanazawa.rb is a nonprofit community for anyone interested in Ruby and Kanazawa based in Kanazawa, Ishikawa, Japan.

#### Project Age ####

10 years

#### Number Of Core Contributors ####

There are 7 core staffs, currently.

#### Project Website ####

https://meetup.kzrb.org/

#### Repository URL(s) ####

https://github.com/kanazawarb

#### Latest Release URL(s) ####

NaN

#### License Type ####

NaN

#### License URL ####

NaN


## A Bit About Yourself  ##

#### Name ####

Tomokazu Kiyohara

#### Email ####

tomokazu.kiyohara@gmail.com

#### Project Role ####

The fhief organizer

#### Profile/Website ####

https://github.com/kiyohara


#### Comments ####

I have a lot of respect for this program for open source projects. I have been using 1Password for many years personally and know that it is the best tool in password sharing. I hope this application will be accepted. Thank you!