### PR TITLE
added Mastodon pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2765,3 +2765,8 @@ https://github.com/monicahq/monica
 ### Django Custom User
 
 [django-custom-user](https://github.com/jcugat/django-custom-user) is a custom user model for Django with the same behaviour as the default User class but without a username field.
+
+### Mastodon pro
+
+is providing hosting services for the decentralized, open-source social network [Mastodon](https://joinmastodon.org), that puts users in control of their data and communication.
+<https://github.com/mastodonpro>


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####
[https://mastodonpro.1password.com]

#### Project Name ####
Mastodon pro

#### Short Description ####
Mastodon pro is providing hosting services for the decentralized, open-source social network [Mastodon](https://joinmastodon.org), that puts users in control of their data and communication. It is officially endorsed by the founders of Mastodon.

#### Project Age ####
2 month (for the hosting part), the main project is 6y

#### Number Of Core Contributors ####
4 (on the hosting part)

#### Project Website ####
[https://joinmastodon.org] (hosting page to be created)

#### Repository URL(s) ####
[https://github.com/mastodonpro]

#### Latest Release URL(s) ####
[https://github.com/mastodonpro/terraform/releases/tag/v1.0.0)] - we're still bootstrapping.

#### License Type ####
AGPLv3

#### License URL ####
[https://github.com/mastodonpro/terraform/blob/main/LICENSE]

## A Bit About Yourself  ##

I'm an entrepreneur active in the Open Source space since many years. Positions included Gentoo Linux (net/zope herd lead), Zope and Plone Foundations (Board or directors).

#### Name ####

Jodok Batlogg

#### Email ####

jodok@batlogg.com

#### Project Role ####

CTO

#### Profile/Website ####
[LinkedIn](http://linkedin.com/in/jodok/)

#### Comments ####
thanks for supporting open source projects!