### PR TITLE
Add OpenMW project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2765,3 +2765,7 @@ https://github.com/monicahq/monica
 ### Django Custom User
 
 [django-custom-user](https://github.com/jcugat/django-custom-user) is a custom user model for Django with the same behaviour as the default User class but without a username field.
+
+### OpenMW
+
+[OpenMW](https://openmw.org/) is an open-source open-world RPG game engine that supports playing Morrowind by Bethesda Softworks.


### PR DESCRIPTION
## Your Project ##
OpenMW

#### 1Password Teams URL ####
[https://openmw.1password.com](https://openmw.1password.com)

#### Project Name ####
OpenMW

#### Short Description ####
OpenMW is a free, open source, and modern engine which re-implements and extends the 2002 Gamebryo engine for the open-world role-playing game [The Elder Scrolls III: Morrowind](https://www.uesp.net/wiki/Morrowind:Morrowind). Like the Construction Set for the original Morrowind engine, OpenMW comes with its own editor, called OpenMW-CS, which allows the user to edit or create their own mods or original games.

#### Project Age ####
15 years

#### Number Of Core Contributors ####
20

#### Project Website ####
https://openmw.org/

#### Repository URL(s) ####
https://gitlab.com/OpenMW/openmw

#### Latest Release URL(s) ####
https://gitlab.com/OpenMW/openmw/-/releases

#### License Type ####
GPLv3

#### License URL ####
https://gitlab.com/OpenMW/openmw/-/blob/master/LICENSE

## A Bit About Yourself  ##
I'm Bret Curtis, project lead for OpenMW and software engineer by professional and father of 3. :)

#### Name ####
Bret Curtis

#### Email ####
psi29a@gmail.com

#### Project Role ####
Project Lead

#### Profile/Website ####
https://github.com/psi29a
https://gitlab.com/psi29a

#### Comments ####
We have a non trivial amount of outreach projects that require proper storage of credentials, ranging from Debian and Arch keys to passwords for account on youtube, twitter, nexus and more. This would allow us to centralise access to these credentials and also assign who has what access. We'd really appreciate the ability to use 1password. Cheers! :)