### PR TITLE
fix missing `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,7 +1497,7 @@ https://opentelemetry.io/
 ### OpenFeature
 
 An open standard for feature flag management.
-https:/openfeature.dev/
+https://openfeature.dev/
 
 ### Botanit(ism)
 


### PR DESCRIPTION
The URL for openfeature was missing a `/`
