### PR TITLE
Add paper-to-git project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2795,7 +2795,7 @@ https://github.com/drud/ddev
 
 [OpenMW](https://openmw.org/) is an open-source open-world RPG game engine that supports playing Morrowind by Bethesda Softworks.
 
-### pape-to-git
+### paper-to-git
 [Paper-to-git](https://github.com/maxking/paper-to-git) is an open source application to synchronize Dropbox paper using its API with a local Git repo. It allows users to also use a small webapp to browser their documents locally.
 
 

--- a/README.md
+++ b/README.md
@@ -2794,3 +2794,8 @@ https://github.com/drud/ddev
 ### OpenMW
 
 [OpenMW](https://openmw.org/) is an open-source open-world RPG game engine that supports playing Morrowind by Bethesda Softworks.
+
+### pape-to-git
+[Paper-to-git](https://github.com/maxking/paper-to-git) is an open source application to synchronize Dropbox paper using its API with a local Git repo. It allows users to also use a small webapp to browser their documents locally.
+
+


### PR DESCRIPTION
## paper-to-git ##

#### 1Password Teams URL ####
https://maxking.1password.com/

#### Project Name ####
paper-to-git

#### Short Description ####
[Paper-to-git](https://github.com/maxking/paper-to-git) is an open source application to synchronize Dropbox paper using its API with a local Git repo. It allows users to also use a small webapp to browser their documents locally.

#### Project Age ####
5.5 years

#### Number Of Core Contributors ####
1

#### Project Website ####
https://github.com/maxking/paper-to-git

#### Repository URL(s) ####
https://github.com/maxking/paper-to-git

#### Latest Release URL(s) ####
https://github.com/maxking/paper-to-git/releases/tag/v0.1.3

#### License Type ####
<!-- e.g. MIT, BSD, GPL, etc. -->
Apache-2.0

#### License URL ####
<!-- A copy of the license terms and conditions for your software -->
https://github.com/maxking/paper-to-git/blob/master/LICENSE

## A Bit About Yourself  ##
I am an software developer by profession and works at LinkedIn in $dayjob. I work on/maintain multiple open source project, including paper-to-git, [GNU Mailman](https://list.org) and am a core CPython contributor.

#### Name ####
Abhilash Raj

#### Email ####
maxking@asynchronous.in

#### Project Role ####
Lead Maintainer

#### Profile/Website ####
<!-- link to GitHub profile page, project page bio, etc. -->
https://github.com/maxking

#### Comments ####
Thanks for the open source offering, this is truly great effort from 1password team :-) 👍🏽 