### PR TITLE
Add Boston Aquarium Society

### DIFF
--- a/README.md
+++ b/README.md
@@ -2801,3 +2801,7 @@ https://github.com/drud/ddev
 
 ### paper-to-git
 [Paper-to-git](https://github.com/maxking/paper-to-git) is an open source application to synchronize Dropbox paper using its API with a local Git repo. It allows users to also use a small webapp to browser their documents locally.
+
+### Boston Aquarium Society
+
+The [Boston Aquarium Society](https://bostonaquariumsociety.org/), founded in 1916, is one of the oldest aquarium hobbyist club in the United States and is dedicated to increasing both knowledge and interest in the aquarium hobby. 


### PR DESCRIPTION
## Boston Aquarium Society ##

#### 1Password Teams URL ####

https://team-bostonaquariumsociety.1password.com

#### Project Name ####

bostonaquariumsociety

#### Short Description ####

The [Boston Aquarium Society](https://bostonaquariumsociety.org/), founded in 1916, is one of the oldest aquarium hobbyist club in the United States and is dedicated to increasing both knowledge and interest in the aquarium hobby. 

#### Project Age ####

13 months

#### Number Of Core Contributors ####

2

#### Project Website ####

https://bostonaquariumsociety.org/

#### Repository URL(s) ####

https://github.com/Boston-Aquarium-Society

#### Latest Release URL(s) ####

N/A

#### License Type ####

MIT

#### License URL ####

https://github.com/Boston-Aquarium-Society/bas-user-guides/blob/main/LICENSE

## A Bit About Yourself  ##

#### Name ####

James Curtin

#### Email ####

jameswcurtin@gmail.com

#### Project Role ####

Webmaster

#### Profile/Website ####

https://github.com/jamescurtin

#### Comments ####
