### PR TITLE
Add MPI Forum to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2817,3 +2817,7 @@ https://github.com/drud/ddev
 ### Boston Aquarium Society
 
 The [Boston Aquarium Society](https://bostonaquariumsociety.org/), founded in 1916, is one of the oldest aquarium hobbyist club in the United States and is dedicated to increasing both knowledge and interest in the aquarium hobby. 
+
+### MPI Forum
+
+The [MPI Forum](https://mpi-forum.org) is the standardization forum for the Message Passing Interface (MPI), one of the most used methods of communication in High Performance Computing (HPC) applications. The MPI Forum includes members from industry, academia, and laboratories from around the world who gather to update the MPI Standard in ways to add exciting new features to support future HPC work.


### PR DESCRIPTION
Add description for the MPI Forum

## Your Project ##

MPI Forum

#### 1Password Teams URL ####
mpi-forum.1password.com

#### Project Name ####

MPI Forum

#### Short Description ####

The [MPI Forum](https://mpi-forum.org) is the standardization forum for the Message Passing Interface (MPI), one of the most used methods of communication in High Performance Computing (HPC) applications. The MPI Forum includes members from industry, academia, and laboratories from around the world who gather to update the MPI Standard in ways to add exciting new features to support future HPC work.

#### Project Age ####

30 years

#### Number Of Core Contributors ####

About 10 - 15 officers and leaders who would have accounts. About 30 - 40 contributors to the MPI Standard.

#### Project Website ####

https://mpi-forum.org

#### Repository URL(s) ####

https://github.com/mpi-forum/mpi-issues

#### Latest Release URL(s) ####

https://www.mpi-forum.org/docs/mpi-4.0/mpi40-report.pdf

#### License Type ####
Custom license for the document

#### License URL ####
©1993, 1994, 1995, 1996, 1997, 2008, 2009, 2012, 2015, 2021 University of Tennessee, Knoxville, Tennessee. Permission to copy without fee all or part of this material is granted, provided the University of Tennessee copyright notice and the title of this document appear, and notice is given that copying is by permission of the University of Tennessee.

## A Bit About Yourself  ##

#### Name ####

Wes Bland

#### Email ####

work@wesbland.com

#### Project Role ####

MPI Forum Secretary

#### Profile/Website ####
https://github.com/wesbland

#### Comments ####
The MPI Forum recently joined [Software in the Public Interest](https://www.spi-inc.org/projects/mpi-forum/) to gain the benefits of a 501c. They are helping us work through any potential legal issues to open source our standard document itself, but in the meantime, all of our work is done in the public repository linked above.