### PR TITLE
add holidays-jp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2843,3 +2843,7 @@ This is a fork of [corkscrew](https://github.com/bryanpkc/corkscrew) developed i
 ### Tekton
 
 [Tekton](https://tekton.dev/) is a powerful and flexible open-source framework for creating CI/CD systems, allowing developers to build, test, and deploy across cloud providers and on-premise systems.
+
+### holidays-jp
+
+[holidays-jp](https://holidays-jp.github.io/) is API service to get Japanese national holidays data. <https://github.com/holidays-jp>


### PR DESCRIPTION
## holidays-jp ##

#### 1Password Teams URL ####
https://monaural.1password.com/

#### Project Name ####
holidays-jp

#### Short Description ####
API service to get Japanese national holidays data, like this
<https://holidays-jp.github.io/api/v1/date.json>

document page (Japanese) is here,
<https://holidays-jp.github.io/>

#### Project Age ####
7 years (since 2016)

#### Number Of Core Contributors ####
2

#### Project Website ####
<https://holidays-jp.github.io/>

#### Repository URL(s) ####
<https://github.com/holidays-jp>

#### Latest Release URL(s) ####
<https://github.com/holidays-jp/api>

#### License Type ####
MIT

#### License URL ####
https://github.com/holidays-jp/holidays-jp.github.io/blob/master/LICENSE

## A Bit About Yourself  ##

#### Name ####
matsuoshi

#### Email ####
matsuoshi@gmail.com

#### Project Role ####
owner, main maintainer

#### Profile/Website ####
https://github.com/matsuoshi

#### Comments ####
Thanks for having these plans!