### PR TITLE
adding CNCF to 1password

### DIFF
--- a/README.md
+++ b/README.md
@@ -2843,3 +2843,7 @@ This is a fork of [corkscrew](https://github.com/bryanpkc/corkscrew) developed i
 ### Tekton
 
 [Tekton](https://tekton.dev/) is a powerful and flexible open-source framework for creating CI/CD systems, allowing developers to build, test, and deploy across cloud providers and on-premise systems.
+
+### Cloud Native Computing Foundation (CNCF)
+
+[CNCF](https://www.cncf.io/) is the open source, vendor-neutral hub of cloud native computing, hosting projects like Kubernetes and Prometheus to make cloud native universal and sustainable.


### PR DESCRIPTION
## Cloud Native Computing Foundation (CNCF) ##

#### 1Password Teams URL ####
https://cloudnativecomputingfoundationcn.1password.com/

#### Project Name ####
Cloud Native Computing Foundation (CNCF)

#### Short Description ####
CNCF is the open source, vendor-neutral hub of cloud native computing

#### Project Age ####
Founded in 2015

#### Number Of Core Contributors ####
1Password will be used by 20-30 staff and community members

#### Project Website ####
https://www.cncf.io/

#### Repository URL(s) ####
https://github.com/cncf

#### Latest Release URL(s) ####
n/a

#### License Type ####
Apache 2.0 - [CNCF IP Policy ](https://github.com/cncf/foundation/blob/main/charter.md)

#### License URL ####
https://github.com/cncf/landscape/blob/master/LICENSE


## A Bit About Yourself  ##

#### Name ####
Taylor Waggoner

#### Email ####
twaggoner@linuxfoundation.org

#### Project Role ####
Program Manager

#### Profile/Website ####
https://github.com/taylorwaggoner

#### Comments ####
Thanks so much for this program!  We'll be using this account to manage and share passwords with our team and community members/CNCF projects as needed. 