### PR TITLE
Added the Rucksack open source project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2878,3 +2878,7 @@ With [Kabootar](https://staging.kabootar.potatokitty.me/), now you can share all
 
 ### Gensosenkyo
 [Gensosenkyo](https://election.suikoden.info/) is a popularity vote event for game characters held by volunteers. In conducting the event, we are developing OSS to collect tweets and creating a Web API to return information about game productions. These have been improved a little each time the event is held. cf. https://github.com/true-runes
+
+### Rucksack
+Rucksack is a CLI tool written in Rust that can backup and maintain passwords from remote services (file store is encrypted, and sensitive records in the filestore are also encrypted). It also supports exporting files for use by services for importing. It can manage passwords, service credentials, cert files, and asymmetric crypto files (public/private keys). 
+https://github.com/oxur/rucksack


### PR DESCRIPTION
## Your Project ##

#### 1Password Teams URL ####

https://rucksackopensourceproject.1password.com/home

#### Project Name ####

Rucksack

#### Short Description ####

Rucksack is a CLI tool written in Rust that can backup and maintain passwords from remote services (file store is encrypted, and sensitive records in the file store are also encrypted). It also supports exporting files for use by services for importing. It can manage passwords, service credentials, cert files, and asymmetric crypto files (public/private keys).

#### Project Age ####

Two months.

#### Number Of Core Contributors ####

Currently two; a few more have expressed interest in contributing, so there may be more soon.

#### Project Website ####

https://github.com/oxur/rucksack

#### Repository URL(s) ####

https://github.com/oxur/rucksack

#### Latest Release URL(s) ####

https://github.com/oxur/rucksack/releases/tag/0.7.1

#### License Type ####

Apache 2.0

#### License URL ####

https://opensource.org/licenses/Apache-2.0

## A Bit About Yourself  ##

#### Name ####

Duncan McGreggor

#### Email ####

oubiwann@gmail.com

#### Project Role ####

Maintainer

#### Profile/Website ####

https://www.linkedin.com/in/oubiwann/

#### Comments ####

1Password comes highly recommended by my peers (I used it ages ago, I think around 2009) and I'd like to make it the preferred service for the users of Rucksack.
