### PR TITLE
Add Polish Demoscene Chronicles team

### DIFF
--- a/README.md
+++ b/README.md
@@ -2886,3 +2886,7 @@ With [Kabootar](https://staging.kabootar.potatokitty.me/), now you can share all
 ### Rucksack
 Rucksack is a CLI tool written in Rust that can backup and maintain passwords from remote services (file store is encrypted, and sensitive records in the filestore are also encrypted). It also supports exporting files for use by services for importing. It can manage passwords, service credentials, cert files, and asymmetric crypto files (public/private keys). 
 https://github.com/oxur/rucksack
+
+### Komitet Społeczny Kronika Polskiej Demosceny (Polish Demoscene Chronicles)
+The “[Polish Demoscene Chronicles](https://kskpd.pl/en)” works closely with demoscene groups, cultural organizations, and researchers focusing on digital culture and art.
+https://github.com/Kronika-Polskiej-Demosceny


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
https://kskpd.1password.com

#### Project Name
Komitet Społeczny Kronika Polskiej Demosceny (Polish Demoscene Chronicles)

#### Short Description
We have successfully enlisted polish demoscene as UNESCO's Intangible Cultural Heritage. We work closely with demoscene groups, cultural organizations, and researchers focusing on digital culture and art.

#### Project Age
3.5 years, give or take.

#### Number Of Core Contributors
5

#### Project Website
https://kskpd.pl

#### Repository URL(s)
https://github.com/Kronika-Polskiej-Demosceny

#### Latest Release URL(s)

#### License
CC0-1.0, CC4.0

## A Bit About Yourself
I'm a long time demoscener, researcher, speaker, lecturer. Co-founder of KSKPD.

#### Name
Andrzej Lichnerowicz

#### Email
angelo@kskpd.pl

#### Project Role
Digital cultural heritage preservation.

#### Profile/Website
https://andrzej.lichnerowicz,pl

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [X] Yes, I'm open.
