### PR TITLE
question about ResearchOps Community account

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ https://opencad.io
 The [ResearchOps Community](https://researchops.community/) is volunteer run group of user researchers, and other people who do user/design research in their jobs, where we share what we know about making research work better within organisations. As a community we create and share learning resources, and run regular events and workshops to share what we learn, about making research accessible inside organisations, whilst respecting the wishes and privacy of the participants.
 [ResearchOps on Medium](https://medium.com/researchops-community) | [ResearchOps on github](http://github.com/researchops)
 
+Note: this account needs our two-year membership converted into one that doesn't need to be renewed.
+
 ### Babel
 
 Babel is a compiler for writing next generation JavaScript.


### PR DESCRIPTION
The ResearchOps 1Password Teams account is about to expire. As it was created before November 26, 2021 we were needing to renew every 2 years. Our emails to both the opensource@1password.com and the help emails have not been responded to and the account says that the trial ends in 3-days. Will you help us figure this out? Many thanks!

## Your Project

#### 1Password Teams URL
<!--
  Make sure you create an account before applying. Don't have one?
  https://start.1password.com/signup/?t=B
  
  Example: myteam.1password.com
-->

#### Project Name
<!--
  If this is for a team that works on multiple projects, a team name
  can be used instead.
-->

#### Short Description

#### Project Age
<!--
  Your project needs to be active and at least 30 days old to be
  eligible for this program.
-->

#### Number Of Core Contributors

#### Project Website

#### Repository URL(s)

#### Latest Release URL(s)

#### License
<!--
  Please include the type (e.g. MIT, BSD, GPL, etc.), and a link
  to where it can be found in your repository.
-->

## A Bit About Yourself

#### Name

#### Email
<!-- We will use this to validate the application with your account -->

#### Project Role

#### Profile/Website
<!-- Link to GitHub profile page, project page bio, etc. -->

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
