### PR TITLE
Add eBPF Foundation to ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2995,3 +2995,6 @@ A container that uses [trunk-recorder](https://github.com/robotastic/trunk-recor
 Support for streaming to https://www.broadcastify.com/ is also included.
 We stream to - https://www.broadcastify.com/listen/feed/30028
 
+### ebpf-foundation
+[ebpf-foundation](https://ebpf.foundation)
+The number of eBPF-based projects has exploded in recent years and many more have been announcing intent to start adopting the technology. eBPF is quickly becoming one of the most influential technologies in the infrastructure software world. As such, the demand is high to optimize collaboration between projects and ensure that the core of eBPF is well maintained and equipped with a clear roadmap and vision for the bright future ahead of eBPF. This is where the eBPF Foundation comes in, and establishes an eBPF steering committee to take care of the technical direction and vision of eBPF.


### PR DESCRIPTION
This patch adds eBPF Foundation details to Readme.

## Your Project

#### 1Password Teams URL
https://ebpffoundation.1password.com/

#### Project Name
eBPF Foundation

#### Short Description
The number of eBPF-based projects has exploded in recent years and many more have been announcing intent to start adopting the technology. eBPF is quickly becoming one of the most influential technologies in the infrastructure software world. As such, the demand is high to optimize collaboration between projects and ensure that the core of eBPF is well maintained and equipped with a clear roadmap and vision for the bright future ahead of eBPF. This is where the eBPF Foundation comes in, and establishes an eBPF steering committee to take care of the technical direction and vision of eBPF.

#### Project Age
1 Year

#### Number Of Core Contributors
20

#### Project Website
https://ebpf.foundation

#### Repository URL(s)
https://github.com/ebpffoundation/


#### Latest Release URL(s)
Yet to happen - in next 3 months


#### License
Apache V2. One of foundation project's license. A project under foundation will be added in 2 months time.

## A Bit About Yourself

#### Name
Sridhar K. N. Rao

#### Email
1password@ebpf.foundation

#### Project Role
Technical Project Manager for the eBPF foundation

#### Profile/Website
https://github.com/sknrao

#### Anything else to add?
This is a foundation under which technical projects will get added. The potential projects are listed in https://ebpf.foundation/projects/ . First project from this list will be added in mid-April and first official release of that project will happen in End of May.

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [ Y] Yes, I'm open.
