### PR TITLE
Show Current Width WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3251,3 +3251,7 @@ https://immich.app
 ### SOPS
 SOPS (Secret OPerationS), a [Cloud Native Computing Foundation](https://cncf.io/) Sandbox project, is an editor in the form of a command-line tool and SDK designed to help manage sensitive content stored within structured files. Various formats, including YAML, JSON, ENV and binary, are supported and their content is managed by encrypting only the values portion of a key/value pair to maintain their readability as it lies at rest.
 https://github.com/getsops/sops
+
+### Show Current Width
+Show Current Width is a WordPress plugin which shows a current screen width on WP adminbar.
+https://github.com/web83info/show-current-width


### PR DESCRIPTION
Add Show Current Width

## Your Project

#### 1Password Teams URL
web83info.1password.com

#### Project Name
Web83

#### Short Description
Web83 is a software development team focused on WordPress development.

#### Project Age
Our first open source WordPress plugin is open to public on July 6, 2023. (33 days ago)

#### Number Of Core Contributors
1

#### Project Website
https://github.com/web83info

#### Repository URL(s)
https://github.com/web83info/show-current-width

#### Latest Release URL(s)
https://github.com/web83info/show-current-width/releases/tag/v1.1.1

#### License
GPLv2 or later
https://github.com/web83info/show-current-width/blob/main/readme.txt

## A Bit About Yourself
We have been working on WordPress developement for over 10 years.

#### Name
Hirayama, Tomoharu (Web83info)

#### Email
me@web83.info

#### Project Role
Developer

#### Profile/Website
https://github.com/web83info

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.