### PR TITLE
Add Kube Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -3314,3 +3314,7 @@ We're one of the only high school hackathons in Canada, running annual events th
 ### fortserver
 FortServer is the open-source Bastion Host and is licensed under the GPLv3. It is a 4A-compliant professional operation and maintenance security audit system.
 https://github.com/skysecs/fortserver
+
+### Kube Logging
+Accessible, understandable, and straightforward logging on Kubernetes.
+https://kube-logging.dev


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL

kubelogging.1password.com


#### Project Name

Kube Logging

#### Short Description

The Kube Logging project contains tools that make logging on Kubernetes an accessible, understandable, and straightforward process for everyone.

#### Project Age

The project has been active for at least 3 years now. It's actively developed by @cisco and @axoflow.

#### Number Of Core Contributors

5 right now, but we are in the process of scaling the project up. We expect 10-15 active maintainers.

#### Project Website

https://kube-logging.dev

#### Repository URL(s)

https://github.com/kube-logging/logging-operator

#### Latest Release URL(s)

https://github.com/kube-logging/logging-operator/releases/tag/4.3.0

#### License

Apache 2.0

https://github.com/kube-logging/logging-operator/blob/master/LICENSE

## A Bit About Yourself

#### Name

Márk Sági-Kazár

#### Email

mark@sagikazarmark.hu

kube-logging@sagikazarmark.hu

#### Project Role

Core Maintainer, DevRel

#### Profile/Website

https://sagikazarmark.hu/
https://github.com/sagikazarmark

#### Anything else to add?

I'm a CNCF Ambassador and has been leading the CNCF application of Kube Logging which has been accepted recently: https://github.com/cncf/sandbox/issues/42

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
