### PR TITLE
adding PyTexas Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3314,3 +3314,7 @@ We're one of the only high school hackathons in Canada, running annual events th
 ### fortserver
 FortServer is the open-source Bastion Host and is licensed under the GPLv3. It is a 4A-compliant professional operation and maintenance security audit system.
 https://github.com/skysecs/fortserver
+
+### PyTexas Foundation
+The PyTexas Foundation is a 501(c)3 non-profit run by a Texas-based volunteer group. We are Python enthusiasts that want to share the programming language with the world, starting right here in Texas. We currently facilitate the PyTexas Conference (The oldest regional Python conference in North America) and the PyTexas Meetup.
+


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
pytexas.1password.com

#### Project Name
PyTexas Foundation

#### Short Description
The PyTexas Foundation is a 501(c)3 non-profit run by a Texas-based volunteer group. We are Python enthusiasts that want to share the programming language with the world, starting right here in Texas. We currently facilitate the PyTexas Conference (The oldest regional Python conference in North America) and the PyTexas Meetup.

#### Project Age
9 years

#### Number Of Core Contributors
7

#### Project Website
https://pytexas.org

#### Repository URL(s)
https://github.com/pytexas

#### Latest Release URL(s)
https://github.com/pytexas/pytexas.github.io
https://github.com/pytexas/2024
https://github.com/pytexas/meetup

#### License
MIT

## A Bit About Yourself

#### Name
Mason  Egger

#### Email
mason@pytexas.org

#### Project Role
President of the PyTexas Foundation

#### Profile/Website
https://github.com/pytexas
https://pytexas.org

#### Anything else to add?
We have already been using 1password for quite some time, and doing this will allow us to onboard new members.

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [X] Yes, I'm open.
