### PR TITLE
Add Open Source Observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3335,3 +3335,7 @@ https://kube-logging.dev
 ### go2rtc
 Ultimate camera streaming application with support RTSP, RTMP, HTTP-FLV, WebRTC, MSE, HLS, MP4, MJPEG, HomeKit, FFmpeg, etc.
 https://github.com/AlexxIT/go2rtc
+
+### Open Source Observer
+Open Source Observer is a free analytics suite that helps funders measure the impact of open source software contributions to the health of their ecosystem.
+https://www.opensource.observer


### PR DESCRIPTION
Adding opensource.observer

## Your Project

#### 1Password Teams URL
https://karibalabs.1password.com/

#### Project Name
Kariba Labs

#### Short Description

#### Project Age
2 months

#### Number Of Core Contributors
3

#### Project Website
https://www.opensource.observer

#### Repository URL(s)
https://github.com/opensource-observer/oso

#### Latest Release URL(s)
Open Source Observer is continuously deployed via Vercel and GitHub actions
https://github.com/opensource-observer/oso/pulls?q=is%3Apr+is%3Aclosed
https://github.com/opensource-observer/oso/actions

#### License
Apache 2.0
https://github.com/opensource-observer/oso/blob/main/LICENSE

## A Bit About Yourself

#### Name
Raymond Cheng

#### Email
ray@karibalabs.co

#### Project Role
Tech lead

#### Profile/Website
- https://github.com/ryscheng
- https://www.linkedin.com/in/ryscheng/
- https://www.raymondcheng.net/

#### Anything else to add?
Kariba Labs is the name of the team that is maintaining open source observer

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
