### PR TITLE
Add Universal Blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3335,3 +3335,7 @@ https://kube-logging.dev
 ### go2rtc
 Ultimate camera streaming application with support RTSP, RTMP, HTTP-FLV, WebRTC, MSE, HLS, MP4, MJPEG, HomeKit, FFmpeg, etc.
 https://github.com/AlexxIT/go2rtc
+
+### Universal Blue 
+Customized Fedora Linux based immutable desktop distros (Silverblue, Kinoite, Sericea, etc) and CoreOS, providing hardware enablement and quality of life improvements, utilizing cloud-native tooling (ostree-container-native, Containers, podman, CI) for build and delivery.
+https://universal-blue.org/


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
ublue.1password.com


#### Project Name
Universal Blue

#### Short Description
Community built OS images based on Fedora

#### Project Age
10 months (Dec 8, 2022 is the official org creation)

#### Number Of Core Contributors
8

#### Project Website
https://universal-blue.org/

#### Repository URL(s)
https://github.com/ublue-os

#### Latest Release URL(s)
https://github.com/orgs/ublue-os/packages?repo_name=main

#### License
Apache 2.0
https://github.com/ublue-os/main/blob/main/LICENSE

## A Bit About Yourself
Longtime software engineer/system admin (DevOps before it had a name). Universal Blue is the first open source project where I've been a major contributor, though I've contributed bits to others over the years. Longtime 1Password customer, managing a family account of my own.

#### Name
Benjamin Sherman

#### Email
benjamin@holyarmy.org

#### Project Role
Approver ( https://github.com/orgs/ublue-os/teams/approver ) 
https://universal-blue.org/membership/#approver

#### Profile/Website
https://github.com/bsherman

#### Anything else to add?
Appreciate this product and your support of open source. 

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [X] Yes, I'm open.
