### PR TITLE
react-native-mapbox-gl => rnmapbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,10 +1063,10 @@ https://www.openttd.org/
 The Flux project aspires to be a vendor-neutral home for GitOps in a Cloud Native world.
 https://fluxcd.io/
 
-### React-Native-Mapbox-GL
+### ReactNative Mapbox
 
-An unofficial React Native library for building maps with the Mapbox Maps SDK for iOS and Mapbox Maps SDK for Android
-https://github.com/react-native-mapbox-gl/maps
+Community-supported, open-source React Native library for building maps with the Mapbox Maps SDK for iOS and Mapbox Maps SDK for Android
+https://github.com/rnmapbox/maps
 
 ### Fork CMS
 


### PR DESCRIPTION
We've renamed our GitHub organisation from react-native-mapbox-gl to rnmapbox

## Your Project

#### 1Password Teams URL
https://rnmapbox.1password.com/signin

#### Project Name
rnmapbox

#### Short Description

#### Project Age
3 years

#### Number Of Core Contributors
2

#### Project Website
https://rnmapbox.github.io

#### Repository URL(s)
https://github.com/rnmapbox/maps

#### Latest Release URL(s)
https://www.npmjs.com/package/@rnmapbox/maps/v/10.0.15

#### License
MIT
https://github.com/rnmapbox/maps/blob/main/LICENSE.md

## A Bit About Yourself

#### Name
Miklós Fazekas

#### Email
mfazekas@szemafor.com

#### Project Role
Maintainer

#### Profile/Website
https://github.com/mfazekas

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
