### PR TITLE
Add Pretendo Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -3409,3 +3409,8 @@ https://github.com/rustls/rustls
 Klynge is a non-profit organization working to improve welfare and quality of life, we do that through organizing networking events, having people share their experiences, mentoring others and building relationships. Everything we build is released Open Source, most notably our membership system.
 
 https://klyngeorg.no/ https://github.com/klyngeorg
+
+### Pretendo Network
+Free and open source replacement servers for the WiiU and 3DS
+
+https://pretendo.network https://github.com/PretendoNetwork


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
pretendonetwork.1password.com

#### Project Name
Pretendo Network

#### Short Description
Pretendo is a free and open source replacement for the game, and related, servers used by the Wii U and 3DS family of consoles

#### Project Age
7 years. We first began work in 2017

#### Number Of Core Contributors
As an open source project this tends to fluctuate, but around 20 at this time. Not all core members contribute code directly to the repositories, several purely do research or manage other aspects of our services

#### Project Website
https://pretendo.network/

#### Repository URL(s)
We have over 100 repositories, so I'll just link to our org

https://github.com/PretendoNetwork/

#### Latest Release URL(s)
We offer many tools and services, some without official releases on GitHub

#### License
We use a variety of licenses in our repositories, though they are all permissive. We generally use AGPL and GPL licenses, however. Each repository has it's own license, but again we have over 100

## A Bit About Yourself

#### Name
Jonathan Barrow

#### Email
jonbarrow1998@gmail.com

#### Project Role
Founder and lead developer

#### Profile/Website
https://jonbarrow.dev

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.