### PR TITLE
Add RubyKaigi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3409,3 +3409,8 @@ https://github.com/rustls/rustls
 Klynge is a non-profit organization working to improve welfare and quality of life, we do that through organizing networking events, having people share their experiences, mentoring others and building relationships. Everything we build is released Open Source, most notably our membership system.
 
 https://klyngeorg.no/ https://github.com/klyngeorg
+
+### RubyKaigi
+RubyKaigi is the world's largest international conference on the Ruby programming language.
+
+https://rubykaigi.org/


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL

rubykaigi.1password.com

#### Project Name

RubyKaigi

#### Short Description

> RubyKaigi is the world's largest international conference on the Ruby programming language.

#### Project Age

17 years ([Annual conference since 2006](https://rubykaigi.org/2023/past_kaigis))

#### Number Of Core Contributors

10 organizers contributing as a core member

https://rubykaigi.org/2023/about/

#### Project Website

https://rubykaigi.org/

#### Repository URL(s)

We don't have a central repository as we're a tech conference. But we do have some codes to run the conference, and these has actual demand for secret management:

- https://github.com/ruby-no-kai/rubykaigi-nw
- https://github.com/ruby-no-kai/takeout-app
- https://github.com/ruby-no-kai/sponsor-app

#### Latest Release URL(s)

https://rubykaigi.org/2023/

#### License

N/A

## A Bit About Yourself

#### Name

Sorah Fukumori

#### Email

- sorah@rubykaigi.org
- her@sorah.jp

#### Project Role

Organizer & Network Operations Lead

(since 2017)

#### Profile/Website

- https://sorah.jp/
- https://github.com/sorah

#### Anything else to add?

I already use 1Password for Business in my primary job (sorah@cookpad.com).

#### Can we contact you?

We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
