### PR TITLE
Add The Drop Bears

### DIFF
--- a/README.md
+++ b/README.md
@@ -3425,3 +3425,7 @@ https://github.com/cucumber
 Free and open source replacement servers for the WiiU and 3DS
 
 https://pretendo.network https://github.com/PretendoNetwork
+
+### The Drop Bears Robotics
+
+[The Drop Bears](https://www.thedropbears.org.au) are a not-for-profit robotics team from Sydney, Australia, founded in 2013. We give high school age students the opportunity to design, build, and code complex robots in order to compete in the FIRST Robotics Competition and gain crucial skills for study and jobs in a range of STEM fields.


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
thedropbears.1password.com

#### Project Name
The Drop Bears Robotics

#### Short Description
We are The Drop Bears, a not-for-profit robotics team from Sydney, Australia, based out of the Australian Centre For Robotics of the University of Sydney. We were founded in 2013 and have operated every year since. We give high school age students the opportunity to design, build, and code complex robots in order to compete in the FIRST Robotics Competition and gain crucial skills for study and jobs in a range of STEM fields.

#### Project Age
10 years

#### Number Of Core Contributors
20

#### Project Website
https://www.thedropbears.org.au

#### Repository URL(s)
https://github.com/thedropbears

#### Latest Release URL(s)
n/a (we deploy from HEAD)

#### License
[MIT](https://github.com/thedropbears/pycubehammer/blob/main/LICENSE)

## A Bit About Yourself

#### Name
David Vo

#### Email
david@thedropbears.org.au

#### Project Role
Mentor and sysadmin

#### Profile/Website
@auscompgeek

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [ ] Yes, I'm open.
