### PR TITLE
Add tiny11builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3480,3 +3480,7 @@ https://github.com/dbt-athena/dbt-athena
 ### nt_tool
 An award searching project aims to using public data by airlines more efficiently.
 [https://github.com/dev-config/kdocs-script](https://github.com/xmsley614/nt_tool)https://github.com/xmsley614/nt_tool
+
+### tiny11builder
+This tool allows to build a light installation image of Windows 11, by downloading the original ISO file from Microsoft and then removing unwanted components. Unwanted components can be configured in the config file.
+[https://myawesomeproject.org](https://github.com/ianis58/tiny11builder)https://github.com/ianis58/tiny11builder

--- a/README.md
+++ b/README.md
@@ -3482,5 +3482,5 @@ An award searching project aims to using public data by airlines more efficientl
 [https://github.com/dev-config/kdocs-script](https://github.com/xmsley614/nt_tool)https://github.com/xmsley614/nt_tool
 
 ### tiny11builder
-This tool allows to build a light installation image of Windows 11, by downloading the original ISO file from Microsoft and then removing unwanted components. Unwanted components can be configured in the config file.
+This tool allows to build a light installation image of Windows 11, by downloading the original ISO file from Microsoft and then removing unwanted components. Unwanted components can be configured in the config file. \
 https://github.com/ianis58/tiny11builder

--- a/README.md
+++ b/README.md
@@ -3483,4 +3483,4 @@ An award searching project aims to using public data by airlines more efficientl
 
 ### tiny11builder
 This tool allows to build a light installation image of Windows 11, by downloading the original ISO file from Microsoft and then removing unwanted components. Unwanted components can be configured in the config file.
-[https://myawesomeproject.org](https://github.com/ianis58/tiny11builder)https://github.com/ianis58/tiny11builder
+https://github.com/ianis58/tiny11builder


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
[https://tiny11builder.1password.com](https://tiny11builder.1password.com)

#### Project Name
tiny11builder

#### Short Description
This tool allows to build a light installation image of Windows 11, by downloading the original ISO file from Microsoft and then removing unwanted components. Unwanted components can be configured in the config file.

#### Project Age
10m

#### Number Of Core Contributors
2

#### Project Website
[https://github.com/ianis58/tiny11builder](https://github.com/ianis58/tiny11builder)

#### Repository URL(s)
[https://github.com/ianis58/tiny11builder](https://github.com/ianis58/tiny11builder)

#### Latest Release URL(s)
n/a

#### License
MIT
[https://github.com/ianis58/tiny11builder/blob/main/LICENSE](https://github.com/ianis58/tiny11builder/blob/main/LICENSE)

## A Bit About Yourself

#### Name
ianis

#### Email
ianis58@gmail.com

#### Project Role
owner

#### Profile/Website
[https://github.com/ianis58](https://github.com/ianis58)

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
