### PR TITLE
Add TSkaigi

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We'll review all requests and accept them at our discretion. If accepted, your p
 
 ### TSKaigi
 The TSKaigi Association (Japanese: 一般社団法人 TSKaigi Association) is a nonprofit organization to hold an annual Tech Conference about TypeScript in Japan. 
-https://tskaigi.org/
+https://association.tskaigi.org/
 
 ### freeCodeCamp.org
 We help people learn to code for free.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ We'll review all requests and accept them at our discretion. If accepted, your p
 
 ## Open source projects using 1Password Teams
 
-### TSKaigi
+### TSKaigi Association
+
 The TSKaigi Association (Japanese: 一般社団法人 TSKaigi Association) is a nonprofit organization to hold an annual Tech Conference about TypeScript in Japan. 
 https://association.tskaigi.org/
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ We'll review all requests and accept them at our discretion. If accepted, your p
 
 ## Open source projects using 1Password Teams
 
+### TSKaigi
+The TSKaigi Association (Japanese: 一般社団法人 TSKaigi Association) is a nonprofit organization to hold an annual Tech Conference about TypeScript in Japan. 
+https://tskaigi.org/
+
 ### freeCodeCamp.org
 We help people learn to code for free.
 https://www.freecodecamp.org


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL

tskaigi.1password.com

#### Name

TSKaigi Association

#### Short Description

The TSKaigi Association (Japanese: 一般社団法人 TSKaigi Association) is a nonprofit organization to hold an annual Tech Conference about TypeScript in Japan.

#### Project Age

3 months (Since November 2023)

#### Number Of Core Contributors

4 board members

#### Project Website

↓ Association's page
https://association.tskaigi.org/

↓ Conference page(will be published this month)
https://tskaigi.org/

#### Repository URL(s)

* https://github.com/tskaigi/tskaigi.github.io

#### Latest Release URL(s)

* https://typescript-jpc.connpass.com/event/305235/
    * Latest monthly sync-up MTG
* https://twitter.com/tskaigi/status/1743205866223120394
    * Latest announcement (Call for Proposals)

#### License

MIT License

## A Bit About Yourself

#### Name

Shinra Yamkawa

#### Email

yamakawa@tskaigi.org

#### Project Role

Lead of TSKaigi 2024 operation experience team

#### Profile/Website

* https://github.com/OldBigBuddha
* https://twitter.com/OldBigBuddha

#### Anything else to add?

I've already asked the 1Password Bussiness Team if we are included in the target of this project via X and mail. And they said that's fine. So I am applying even though our project is very young and we haven't had any work yet.

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
