### PR TITLE
Add Python India

### DIFF
--- a/README.md
+++ b/README.md
@@ -3537,3 +3537,8 @@ https://redefine.ohevan.com
 ### PyOhio
 PyOhio is a free, regional Python community conference held in Ohio. We bring together folks from Ohio, the surrounding states, and around the world to meet new people and learn from each other.
 https://www.pyohio.org
+
+### Python India
+
+Python India organises PyCon India and maintains the infrastructure and knowledge base required to conduct the event.
+https://github.com/pythonindia

--- a/README.md
+++ b/README.md
@@ -3517,3 +3517,8 @@ International Telephone Input with Vue https://vue-tel-input.iamstevendao.com/
 The ultimate free and open-source macOS screencapture utility.
 https://isharemac.app
 https://github.com/castdrian/ishare
+
+### Python India
+
+Python India organises PyCon India and maintains the infrastructure and knowledge base required to conduct the event.
+https://github.com/pythonindia


### PR DESCRIPTION
## Python India

Python India organizes PyCon India. It is a regional conference held in India annually since 2009. The conference is part of Python Software Foundation, a 501(c)3 entity.

#### 1Password Teams URL

https://team-pythonindia.1password.com/

#### Project Name

Python India Maintainers

#### Short Description

#### Project Age

15 years. Active since 2009.

#### Number Of Core Contributors

~10-15

#### Project Website

https://in.pycon.org/

#### Repository URL(s)

https://github.com/pythonindia

#### Latest Release URL(s)

https://in.pycon.org/2023
https://github.com/pythonindia/inpycon2023

#### License

We use MIT, Apache 2.0 and CC BY-NC-SA 4.0 depending on the type of the content in the repository. We use only permissive licenses.

## A Bit About Yourself

#### Name

Nabarun Pal

#### Email

contact@in.pycon.org / pythonindiaops@gmail.com
Personally, if you want to reach out, hey@naba.run

#### Project Role

Technical Lead

#### Profile/Website

https://nabarun.dev

#### Anything else to add?

PyCon India has been running for the past 15 years. We have checked what other conferences under Python Software Foundation uses for password management. 1password Teams for Open Source is used by many as evident from the README of this repository.

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
