### PR TITLE
Add CNCF project Harbor in 1password

### DIFF
--- a/README.md
+++ b/README.md
@@ -3565,3 +3565,8 @@ https://github.com/bibicadotnet/LCMP-Minimal
 ### TSKaigi Association
 The TSKaigi Association (Japanese: 一般社団法人 TSKaigi Association) is a nonprofit organization to hold an annual Tech Conference about TypeScript in Japan.
 https://association.tskaigi.org/
+
+### Harbor
+Harbor is an open source registry that secures artifacts with policies and role-based access control, ensures images are scanned and free from vulnerabilities, and signs images as trusted. Harbor, a CNCF Graduated project, delivers compliance, performance, and interoperability to help you consistently and securely manage artifacts across cloud native compute platforms like Kubernetes and Docker.
+
+https://goharbor.io


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
goharbor.1password.com

#### Project Name
Harbor

#### Short Description

#### Project Age
since 2016

#### Number Of Core Contributors
9ish

#### Project Website
https://goharbor.io

#### Repository URL(s)
https://github.com/goharbor/harbor/

#### Latest Release URL(s)
https://github.com/goharbor/harbor/releases/tag/v2.10.0

#### License
Apache 2

## A Bit About Yourself
Harbor is an open source registry that secures artifacts with policies and role-based access control, ensures images are scanned and free from vulnerabilities, and signs images as trusted. Harbor, a CNCF Graduated project, delivers compliance, performance, and interoperability to help you consistently and securely manage artifacts across cloud native compute platforms like Kubernetes and Docker.
#### Name

#### Email
cncf-harbor-maintainers@lists.cncf.io

#### Project Role
CNCF Graduated Project

#### Profile/Website
https://goharbor.io

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?
- [X] Yes, I'm open.
