### PR TITLE
Add Paperlib from Future Scholars

### DIFF
--- a/README.md
+++ b/README.md
@@ -3600,3 +3600,7 @@ https://circuitverse.org
 ### S3M
 A command-line tool for storing streams of data in s3 buckets.
 https://s3m.stream
+
+### Paperlib
+An open-source academic paper management tool.
+https://paperlib.app/en


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
https://futurescholars.1password.com/

#### Project Name
Project Name: Paperlib
Org Name: Future Scholars

#### Short Description

Our Paperlib is an open source reference manager designed to improve your citing experience by addressing some of the common painpoints found in other software.

It has been used by scholars around the world.


#### Project Age

Since 2021, 3 years.

#### Number Of Core Contributors

~3

#### Project Website

https://paperlib.app/en/

#### Repository URL(s)

https://github.com/Future-Scholars/paperlib

#### Latest Release URL(s)

https://github.com/Future-Scholars/paperlib/releases/tag/beta-electron-3.0.0-dev.11

#### License
GPL3

## A Bit About Yourself

#### Name

Geoffrey Chen

#### Email
geoffreychen777@gmail.com

#### Project Role

Creator and Leader

#### Profile/Website
https://geoch.top/

#### Anything else to add?

No

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
