### PR TITLE
Update README to be more descriptive, add more details around program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,50 @@
-# 1Password for Open Source Projects
+<div align="center">
+  <h1>1Password for Open Source</h1>
+  <p>1Password relies on open source software every day. It's fair to say that 1Password wouldn't exist without the open source community, so we want to give back and help teams be more productive and secure.</p>
+  <p>Are you working on an open source project? Do you need a place to securely store and share your project's login credentials, API tokens, SSH keys, database information, and morem where you can also use them right in your development workflow? 1Password has your back: get a free Teams account on us.</p>
+  <a href="#-how-to-apply">
+    <img alt="Apply today" src=".github/apply-button.png" height="37"/>
+  </a>
+</div>
 
-We rely on open source software every day to develop 1Password. It's fair to say that 1Password wouldn't exist without the open source community, so we want to give back and help teams be more productive and secure.
+---
 
-Are you working on an open source project that needs a password manager? How about a secure place to keep and share secrets — social media logins, code signing certificates, ssh keys, etc? We've got your back: get 1Password Teams free on us.
+## 📝 How to apply
 
-## How to apply
+Applying is easy! Be sure to review the requirements below, and then complete the following steps:
 
-1. Create a team account: https://start.1password.com/signup/?t=B
-2. Invite at least one other person to your team and [add them to the Owners group](https://support.1password.com/groups/#manage-group-membership).
-3. Fork this repo and add an entry to the `Open source projects using 1Password Teams` section at the bottom of this page:
+1. Before you apply you'll need to be an owner on a 1Password Team account. Don't have an account? [Start a 14 day trial.](https://start.1password.com/signup/?t=B)
+2. In order to decrease the chances of getting locked out, invite at least one other person to your team and [add them to the Owners group](https://support.1password.com/groups/#manage-group-membership).
+3. Submit your application by [**completing this form**](https://github.com/1Password/1password-teams-open-source/issues/new?labels=application&template=application.yml&title=Application+for+[project+name]) and opening a new issue in this repository.
 
-```markdown
-### Project name
-A short description of what we do.
-https://myawesomeproject.org
-```
+## ✅ Requirements
 
-4. Create a pull request and fill out the template with the requested details.
+- This program is only eligible for Teams accounts. Personal, Family, and Business account types are not currently eligible for the program. If you want to maintain your current non-Team account and apply to the program you can considering [changing your account type](https://support.1password.com/change-account-type/).
+- Your 1Password account must not be associated with commercial activity, with the exception of open source funding programs like GitHub Sponsorships or Open Collective. If your company is looking for an enterprise password manager, check out [1Password Business](https://1password.com/business/).
+- If your application is to support a single project, the project must be at least 30 days old and active, it must be under a permissive open source license, and you must be a core contributor.
+- If your application is to support a team, the same rules apply to the projects your team works on. Projects must primarily be open source, and not supported by commercial activity.
+- We’ll also accept applications from the organisers of community meetups, events, as well as some conferences, relating to open source.
 
-## Requirements
+If you're not sure if your project meets these requirements, please contact [opensource@1password.com](mailto:opensource@1password.com) for additional information.
 
-To apply, you need to be a core contributor for an active open source project that is at least 30 days old. We’ll also accept applications from the organisers of community meetups and events, as well as some conferences.
+## 🎁 Membership details
 
-Projects need to use a standard open source license and must be non-commercial. If your company is looking for an enterprise password manager, check out [1Password Business](https://1password.com/business/).
+When you join the program, you'll be getting a free [1Password Teams](https://1password.com/teams) account. Here's what you can expect:
 
-If you're not sure if your project meets these requirements, ask us [@1Password](https://twitter.com/1password) or opensource@1password.com.
+- Your membership does not expire as long as your project remains eligible for the program.
+- Invite as many team members to your project as you need. Accounts in the program are not limited to 10 members.
+- The whole team can use 1Password, everywhere: [Mac](https://1password.com/downloads/mac/), [Windows](https://1password.com/downloads/windows/), [iOS](https://1password.com/downloads/ios/), [Android](https://1password.com/downloads/android/), [Linux](https://1password.com/downloads/linux/), and [in the browser](https://1password.com/downloads/browser-extension/).
+- Developers can integrate 1Password into their development workflows, including [managing SSH keys and signing Git commits](https://1password.com/developers/ssh), [authenticating CLIs with biometrics](https://1password.com/developers/cli), and [securing secrets throughout your project](https://1password.com/developers/secrets-management).
 
-## Membership details
+> [!TIP]
+> If you signed up for this program before November 26, 2021, please contact [opensource@1password.com](mailto:opensource@1password.com) to convert your two-year membership into one that doesn't need to be renewed.
 
-- You'll receive a membership to [1Password Teams](https://1password.com/teams).
-- You can invite core contributors to your team account.
-- Team members can use the 1Password apps on all devices — Mac, Windows, iOS, Android, Linux, Chrome OS and web.
-- Your membership does not expire. If you signed up before November 26, 2021, please contact opensource@1password.com to convert your two-year membership into one that doesn't need to be renewed.
-- Memberships cannot be transferred or sold.
+We'll review all requests and accept them at our discretion. If accepted, details of your participation are recorded in this repository and may be used for promotional purposes. Memberships may be canceled if accounts are found to no longer meet the requirements. Memberships cannot be transferred or sold.
 
-We'll review all requests and accept them at our discretion. If accepted, your project may be listed below. Memberships may be canceled if accounts are found to no longer meet the requirements.
+## 💙 Community & support
+
+- Learn more about 1Password's developer offerings and check out all the documentation on [1Password Developer](https://developer.1password.com/).
+- If you're interested in participating in our developer community, join the [Developer Slack workspace](https://developer.1password.com/joinslack) or subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/).
+- For questions about our products and account support, visit the [1Password Community forums](https://1password.community/) or [1Password Support](https://support.1password.com/).
+
+1Password for Open Source is part of [1Password for Good](https://1password.com/for-good/).


### PR DESCRIPTION
`dev/-/epics/529`

## Summary

We are working on improvements to the 1Password for Open Source program, and this PR updates the main `README` in the following ways:

- Updates language around the program name, which is now "1Password for Open Source"
- Makes the requirements more explicit, including cases around projects vs. teams, conferences and events, etc
- Updates membership details and application steps to be more verbose and provide more resources
- Adds a section around community and support
- Generally stylizes the contents