### PR TITLE
Add HashiCorp Korea User Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -3642,3 +3642,8 @@ https://t.me/VidStickerBot
 ### Commonhaus Foundation
 The Commonhaus Foundation fosters a nurturing home for open-source projects, prioritizing innovation, collaboration, and sustainability. We support the growth and stability of projects through community-driven governance and shared resources, ensuring open-source ecosystems thrive.
 https://www.commonhaus.org
+
+### HashiCorp Korea User Group
+
+HashiCorp Korea User Group is a South Korea based HashiCorp users and contributors community for anyone interested in HashiCorp products and its OSS projects like Terraform, Packer, Consul, Vault, Nomad and more. We organize local HashiCorp meetup and workshop events, and provide online space for Korean HashiCorp users.
+https://www.facebook.com/groups/hashicorpkrug


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL

hashicorp-krug.1password.com

#### Project Name

HashiCorp Korea User Group

#### Short Description

HashiCorp Korea User Group is a South Korea based HashiCorp users and contributors community for anyone interested in HashiCorp products and its OSS projects like Terraform, Packer, Consul, Vault, Nomad and more. We organize local HashiCorp meetup and workshop events, and provide online space for Korean HashiCorp users.

#### Project Age
<!--
  Your project needs to be active and at least 30 days old to be
  eligible for this program.
-->
Since 2017

#### Number Of Core Contributors

5

#### Project Website

https://www.facebook.com/groups/hashicorpkrug

#### Repository URL(s)

https://github.com/hashicorp-krug

#### Latest Release URL(s)

#### License
<!--
  Please include the type (e.g. MIT, BSD, GPL, etc.), and a link
  to where it can be found in your repository.
-->

- [MIT](https://github.com/hashicorp-krug/hashicorp-krug-slackin/blob/master/LICENSE)

## A Bit About Yourself

#### Name

Byungjin Park

#### Email
<!-- We will use this to validate the application with your account -->

posquit0.bj@gmail.com

#### Project Role

Organizer / Founder

#### Profile/Website
<!-- Link to GitHub profile page, project page bio, etc. -->

- https://www.posquit0.com/
- https://github.com/posquit0/
- https://www.linkedin.com/in/posquit0/

#### Anything else to add?

Thank you!

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
