### PR TITLE
fix: change license of Gaze to GPLv3

### DIFF
--- a/data/1606-gaze.json
+++ b/data/1606-gaze.json
@@ -6,7 +6,7 @@
 		"contributors": 2,
 		"home_url": "https://gaze.gundulabs.com",
 		"repo_url": "https://github.com/GunduLabs/gaze",
-		"license_type": "MIT",
+		"license_type": "GPLv3",
 		"license_url": "https://github.com/GunduLabs/gaze/blob/main/LICENSE",
 		"is_event": false,
 		"is_team": true


### PR DESCRIPTION
Gaze recently updated its license from MIT to GPLv3. This PR corrects the license in the Gaze json file.